### PR TITLE
fixes: input, toaster, form

### DIFF
--- a/button/index.js
+++ b/button/index.js
@@ -5,6 +5,10 @@ class TonicButton extends Tonic {
     return this.props.value
   }
 
+  get form () {
+    return this.querySelector('button').form
+  }
+
   get disabled () {
     return this.props.disabled === true
   }

--- a/chart/index.js
+++ b/chart/index.js
@@ -5,7 +5,7 @@ class TonicChart extends Tonic {
     super(o)
 
     try {
-      let dynamicRequire = require
+      const dynamicRequire = require
       this.Chart = dynamicRequire('chart.js')
     } catch (err) {
       console.error('could not find "chart.js" dependency. npm install?')

--- a/chart/index.js
+++ b/chart/index.js
@@ -5,7 +5,8 @@ class TonicChart extends Tonic {
     super(o)
 
     try {
-      this.Chart = require('chart.js')
+      let dynamicRequire = require
+      this.Chart = dynamicRequire('chart.js')
     } catch (err) {
       console.error('could not find "chart.js" dependency. npm install?')
     }

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -25277,6 +25277,10 @@ class TonicToasterInline extends Tonic {
   }
 
   connected () {
+    this.updated()
+  }
+
+  updated () {
     const {
       display,
       duration

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -370,6 +370,10 @@ class TonicButton extends Tonic {
     return this.props.value
   }
 
+  get form () {
+    return this.querySelector('button').form
+  }
+
   get disabled () {
     return this.props.disabled === true
   }
@@ -1448,6 +1452,10 @@ class TonicInput extends Tonic {
     }
   }
 
+  get form () {
+    return this.querySelector('input').form
+  }
+
   get value () {
     return this.state.value
   }
@@ -1623,7 +1631,7 @@ class TonicInput extends Tonic {
       relay('blur')
     })
 
-    input.addEventListener('keyup', e => {
+    input.addEventListener('input', e => {
       set('value', e.target.value)
       set('pos', e.target.selectionStart)
       relay('input')
@@ -1721,7 +1729,8 @@ class TonicInput extends Tonic {
     const spellcheckAttr = spellcheck ? `spellcheck="${spellcheck}"` : ''
     const tabAttr = tabindex ? `tabindex="${tabindex}"` : ''
     const titleAttr = title ? `title="${title}"` : ''
-    const value = this.state.value || this.props.value
+    const value = typeof this.state.value === 'string' ?
+      this.state.value : this.props.value
     const valueAttr = value && value !== 'undefined' ? `value="${value.replace(/"/g, '&quot;')}"` : ''
 
     if (ariaLabelledByAttr) this.removeAttribute('ariaLabelled')

--- a/docs/test.js
+++ b/docs/test.js
@@ -35617,6 +35617,10 @@ class TonicToasterInline extends Tonic {
   }
 
   connected () {
+    this.updated()
+  }
+
+  updated () {
     const {
       display,
       duration

--- a/docs/test.js
+++ b/docs/test.js
@@ -402,6 +402,10 @@ class TonicButton extends Tonic {
     return this.props.value
   }
 
+  get form () {
+    return this.querySelector('button').form
+  }
+
   get disabled () {
     return this.props.disabled === true
   }
@@ -2003,6 +2007,10 @@ class TonicInput extends Tonic {
     }
   }
 
+  get form () {
+    return this.querySelector('input').form
+  }
+
   get value () {
     return this.state.value
   }
@@ -2178,7 +2186,7 @@ class TonicInput extends Tonic {
       relay('blur')
     })
 
-    input.addEventListener('keyup', e => {
+    input.addEventListener('input', e => {
       set('value', e.target.value)
       set('pos', e.target.selectionStart)
       relay('input')
@@ -2276,7 +2284,8 @@ class TonicInput extends Tonic {
     const spellcheckAttr = spellcheck ? `spellcheck="${spellcheck}"` : ''
     const tabAttr = tabindex ? `tabindex="${tabindex}"` : ''
     const titleAttr = title ? `title="${title}"` : ''
-    const value = this.state.value || this.props.value
+    const value = typeof this.state.value === 'string' ?
+      this.state.value : this.props.value
     const valueAttr = value && value !== 'undefined' ? `value="${value.replace(/"/g, '&quot;')}"` : ''
 
     if (ariaLabelledByAttr) this.removeAttribute('ariaLabelled')

--- a/input/index.js
+++ b/input/index.js
@@ -191,7 +191,7 @@ class TonicInput extends Tonic {
       relay('blur')
     })
 
-    input.addEventListener('keyup', e => {
+    input.addEventListener('input', e => {
       set('value', e.target.value)
       set('pos', e.target.selectionStart)
       relay('input')
@@ -289,7 +289,8 @@ class TonicInput extends Tonic {
     const spellcheckAttr = spellcheck ? `spellcheck="${spellcheck}"` : ''
     const tabAttr = tabindex ? `tabindex="${tabindex}"` : ''
     const titleAttr = title ? `title="${title}"` : ''
-    const value = this.state.value || this.props.value
+    const value = typeof this.state.value === 'string' ?
+      this.state.value : this.props.value
     const valueAttr = value && value !== 'undefined' ? `value="${value.replace(/"/g, '&quot;')}"` : ''
 
     if (ariaLabelledByAttr) this.removeAttribute('ariaLabelled')

--- a/input/index.js
+++ b/input/index.js
@@ -293,8 +293,8 @@ class TonicInput extends Tonic {
     const spellcheckAttr = spellcheck ? `spellcheck="${spellcheck}"` : ''
     const tabAttr = tabindex ? `tabindex="${tabindex}"` : ''
     const titleAttr = title ? `title="${title}"` : ''
-    const value = typeof this.state.value === 'string' ?
-      this.state.value : this.props.value
+    const value = typeof this.state.value === 'string'
+      ? this.state.value : this.props.value
     const valueAttr = value && value !== 'undefined' ? `value="${value.replace(/"/g, '&quot;')}"` : ''
 
     if (ariaLabelledByAttr) this.removeAttribute('ariaLabelled')

--- a/input/index.js
+++ b/input/index.js
@@ -16,6 +16,10 @@ class TonicInput extends Tonic {
     }
   }
 
+  get form () {
+    return this.querySelector('input').form
+  }
+
   get value () {
     return this.state.value
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "npm run build && ./bin/server",
     "prepublish": "API=true npm run build",
+    "watch": "chokidar \"src/**/*.js\" -c \"npm run build\"",
     "build": "npm run build:styl && npm run build:docs && npm run build:test",
     "build:test": "node test/old/build.js && browserify ./test/old/test.js > ./docs/test.js",
     "build:docs": "./bin/build-docs && npm run build:docs:js",
@@ -37,6 +38,7 @@
     "autoprefixer-stylus": "^0.14.0",
     "browserify": "^16.2.2",
     "chart.js": "^2.9.2",
+    "chokidar-cli": "2.1.0",
     "highlight.js": "^9.12.0",
     "marked": "^0.7.0",
     "minimist": "^1.2.0",

--- a/toaster-inline/index.js
+++ b/toaster-inline/index.js
@@ -108,6 +108,10 @@ class TonicToasterInline extends Tonic {
   }
 
   connected () {
+    this.updated()
+  }
+
+  updated () {
     const {
       display,
       duration


### PR DESCRIPTION
This fixes some edge cases in components. namely the following

 - Update `tonic-toaster-inline` to add more state in reRender.
This component is now reRender safe so you can update the display
state and `show()` & `hide()` persist among `reRender()`
 - Update `tonic-input` ; Improve event handling and value handling
 - Update `chart` ; support browserify
 - Update `button` support `form` getter.