### PR TITLE
src: Make props.id mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ const bundle = require('@optoolco/components')
 bundle(Tonic)
 ```
 
+#### Strict mode for better error message
+
+```js
+const Tonic = require('@optoolco/tonic')
+const bundle = require('@optoolco/components')
+
+bundle(Tonic, { strict: true })
+```
+
 ### THEME
 Tonic uses CSS variables (which work in all major browsers) to theme components.
 The following variables are observed but are not required.

--- a/accordion/index.js
+++ b/accordion/index.js
@@ -107,6 +107,15 @@ class TonicAccordion extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-accordion')
+    }
+
     const {
       multiple
     } = this.props
@@ -201,6 +210,15 @@ class TonicAccordionSection extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-accordion-section')
+    }
+
     const {
       id,
       name,

--- a/accordion/index.js
+++ b/accordion/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicAccordion extends Tonic {
   defaults () {
     return {
@@ -107,7 +109,8 @@ class TonicAccordion extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    console.log('what', JSON.stringify(mode.strict), this.props.id)
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')
@@ -210,7 +213,7 @@ class TonicAccordionSection extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/accordion/test.js
+++ b/accordion/test.js
@@ -11,7 +11,7 @@ document.body.appendChild(html`
 
   <div id="accordion-1" class="test-container">
     <span>Default</span>
-    <tonic-accordion>
+    <tonic-accordion id="accordion-parent-1">
       <tonic-accordion-section
         name="accordion-test-1"
         id="accordion-test-1"
@@ -35,7 +35,7 @@ document.body.appendChild(html`
 
   <div id="accordion-2" class="test-container">
     <span>Multiple</span>
-    <tonic-accordion multiple="true">
+    <tonic-accordion multiple="true" id="accordion-parent-2">
       <tonic-accordion-section
         name="accordion-test-4"
         id="accordion-test-4"

--- a/badge/index.js
+++ b/badge/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicBadge extends Tonic {
   defaults () {
     return {
@@ -63,7 +65,7 @@ class TonicBadge extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/badge/index.js
+++ b/badge/index.js
@@ -63,6 +63,15 @@ class TonicBadge extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-badge')
+    }
+
     const {
       theme
     } = this.props

--- a/badge/test.js
+++ b/badge/test.js
@@ -11,22 +11,22 @@ document.body.appendChild(html`
 
   <div id="badge-1" class="test-container">
     <span>Default</span>
-    <tonic-badge></tonic-badge>
+    <tonic-badge id="tonic-badge-1"></tonic-badge>
   </div>
 
   <div id="badge-2" class="test-container">
     <span>count="6"</span>
-    <tonic-badge count="6"></tonic-badge>
+    <tonic-badge id="tonic-badge-2" count="6"></tonic-badge>
   </div>
 
   <div id="badge-3" class="test-container">
     <span>theme="light"</span>
-    <tonic-badge count="1" theme="light"></tonic-badge>
+    <tonic-badge id="tonic-badge-3" count="1" theme="light"></tonic-badge>
   </div>
 
   <div id="badge-4" class="dark test-container">
     <span>theme="dark"</span>
-    <tonic-badge count="1" theme="dark"></tonic-badge>
+    <tonic-badge id="tonic-badge-4" count="1" theme="dark"></tonic-badge>
   </div>
 
 </section>

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -139,6 +139,15 @@ class TonicCheckbox extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-checkbox')
+    }
+
     const {
       id,
       disabled,

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicCheckbox extends Tonic {
   get value () {
     const state = this.getState()
@@ -139,7 +141,7 @@ class TonicCheckbox extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ try {
   console.error('Missing dependency. Try `npm isntall @optoolco/tonic`.')
 }
 
+const mode = require('./mode')
+
 const { TonicAccordion, TonicAccordionSection } = require('./accordion')
 const { TonicBadge } = require('./badge')
 const { TonicButton } = require('./button')
@@ -28,7 +30,13 @@ const { TonicToggle } = require('./toggle')
 //
 // An example collection of components.
 //
-module.exports = Tonic => {
+module.exports = components
+
+function components (Tonic, opts) {
+  if (opts && opts.strict === true) {
+    mode.strict = true
+  }
+
   Tonic.add(TonicAccordion)
   Tonic.add(TonicAccordionSection)
   Tonic.add(TonicBadge)

--- a/input/index.js
+++ b/input/index.js
@@ -253,6 +253,15 @@ class TonicInput extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-input')
+    }
+
     const {
       ariaInvalid,
       ariaLabelledby,

--- a/input/index.js
+++ b/input/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicInput extends Tonic {
   defaults () {
     return {
@@ -253,7 +255,7 @@ class TonicInput extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/mode.js
+++ b/mode.js
@@ -1,0 +1,1 @@
+module.exports = { strict: false }

--- a/profile-image/index.js
+++ b/profile-image/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicProfileImage extends Tonic {
   get value () {
     const state = this.getState()
@@ -151,7 +153,7 @@ class TonicProfileImage extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/profile-image/index.js
+++ b/profile-image/index.js
@@ -151,6 +151,15 @@ class TonicProfileImage extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-profile-image')
+    }
+
     const {
       theme,
       editable

--- a/progress-bar/index.js
+++ b/progress-bar/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicProgressBar extends Tonic {
   set value (value) {
     this.setProgress(value)
@@ -64,7 +66,7 @@ class TonicProgressBar extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/progress-bar/index.js
+++ b/progress-bar/index.js
@@ -64,6 +64,15 @@ class TonicProgressBar extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-progress-bar')
+    }
+
     if (this.props.theme) {
       this.classList.add(`tonic--theme--${this.props.theme}`)
     }

--- a/range/index.js
+++ b/range/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicRange extends Tonic {
   defaults () {
     return {
@@ -157,7 +159,7 @@ class TonicRange extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/range/index.js
+++ b/range/index.js
@@ -157,6 +157,15 @@ class TonicRange extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-range')
+    }
+
     const {
       width,
       height,

--- a/router/index.js
+++ b/router/index.js
@@ -80,6 +80,15 @@ class TonicRouter extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-router')
+    }
+
     if (this.hasAttribute('match')) {
       this.setState(TonicRouter.props)
       return this.template.content

--- a/router/index.js
+++ b/router/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicRouter extends Tonic {
   constructor () {
     super()
@@ -80,7 +82,7 @@ class TonicRouter extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/router/test.js
+++ b/router/test.js
@@ -28,7 +28,7 @@ document.body.appendChild(html`
     </tonic-router>
 
     <!-- Router w/ none -->
-    <tonic-router>
+    <tonic-router id="404">
       404
     </tonic-router>
   </div>

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicTabs extends Tonic {
   stylesheet () {
     return `
@@ -93,7 +95,7 @@ class TonicTabs extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')
@@ -152,7 +154,7 @@ class TonicTabPanel extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -93,6 +93,15 @@ class TonicTabs extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-tabs')
+    }
+
     this.setAttribute('role', 'tablist')
 
     return [...this.childNodes].map((node, index) => {
@@ -143,6 +152,15 @@ class TonicTabPanel extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-tab-panel')
+    }
+
     this.setAttribute('role', 'tabpanel')
 
     return this.html`

--- a/tabs/test.js
+++ b/tabs/test.js
@@ -14,7 +14,7 @@ document.body.appendChild(html`
   <div id="tabs-1" class="test-container">
     <span>Default Tabs</span>
 
-    <tonic-tabs selected="tab-2">
+    <tonic-tabs id="tonic-tabs-1" selected="tab-2">
       <tonic-tab
         id="tab-1"
         for="tab-panel-1">One</tonic-tab>
@@ -35,7 +35,7 @@ document.body.appendChild(html`
   <div id="tabs-2" class="test-container">
     <span>Tabs with nesting</span>
 
-    <tonic-tabs selected="tab-4">
+    <tonic-tabs id="tonic-tabs-2" selected="tab-4">
       <tonic-tab
         id="tab-4"
         for="tab-panel-4">One</tonic-tab>
@@ -56,7 +56,7 @@ document.body.appendChild(html`
     </tonic-tab-panel>
     <tonic-tab-panel id="tab-panel-5">
 
-      <tonic-accordion>
+      <tonic-accordion id="accordion-1">
         <tonic-accordion-section
           name="accordion-test-4b"
           id="accordion-test-4b"
@@ -108,7 +108,7 @@ document.body.appendChild(html`
 
       <tonic-tab-panel id="tab-panel-8">
 
-        <tonic-accordion>
+        <tonic-accordion id="accordion-2">
           <tonic-accordion-section
             name="accordion-test-7"
             id="accordion-test-7"

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const components = require('..')
-components(require('@optoolco/tonic'))
+components(require('@optoolco/tonic'), { strict: true })
 
+require('../accordion/test')
 require('../router/test')
 require('../panel/test')
 require('../dialog/test')

--- a/textarea/index.js
+++ b/textarea/index.js
@@ -87,6 +87,15 @@ class TonicTextarea extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-text-area')
+    }
+
     const {
       ariaLabelledby,
       autofocus,

--- a/textarea/index.js
+++ b/textarea/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicTextarea extends Tonic {
   defaults () {
     return {
@@ -87,7 +89,7 @@ class TonicTextarea extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/textarea/test.js
+++ b/textarea/test.js
@@ -6,12 +6,12 @@ document.body.appendChild(html`
 
   <div class="test-container">
     <span>Default Textarea</span>
-    <tonic-textarea></tonic-textarea>
+    <tonic-textarea id="text-area-1"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>With Content</span>
-    <tonic-textarea>It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way—in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.</tonic-textarea>
+    <tonic-textarea id="text-area-2">It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way—in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.</tonic-textarea>
   </div>
 
   <div class="test-container">
@@ -21,127 +21,127 @@ document.body.appendChild(html`
 
   <div class="test-container">
     <span>name="textarea-name"</span>
-    <tonic-textarea name="textarea-name"></tonic-textarea>
+    <tonic-textarea id="text-area-3" name="textarea-name"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>placeholder="This is a placeholder"</span>
-    <tonic-textarea placeholder="This is a placeholder"></tonic-textarea>
+    <tonic-textarea id="text-area-4" placeholder="This is a placeholder"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>resize="none"</span>
-    <tonic-textarea resize="none"></tonic-textarea>
+    <tonic-textarea id="text-area-5" resize="none"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>spellcheck="true"</span>
-    <tonic-textarea spellcheck="true">fdsfds</tonic-textarea>
+    <tonic-textarea id="text-area-6" spellcheck="true">fdsfds</tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>spellcheck="false"</span>
-    <tonic-textarea spellcheck="false">fdsfds</tonic-textarea>
+    <tonic-textarea id="text-area-7" spellcheck="false">fdsfds</tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>disabled="true"</span>
-    <tonic-textarea disabled="true"></tonic-textarea>
+    <tonic-textarea id="text-area-8" disabled="true"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>disabled="false"</span>
-    <tonic-textarea disabled="false"></tonic-textarea>
+    <tonic-textarea id="text-area-9" disabled="false"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>required="true"</span>
-    <tonic-textarea required="true"></tonic-textarea>
+    <tonic-textarea id="text-area-10" required="true"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>required="false"</span>
-    <tonic-textarea required="false"></tonic-textarea>
+    <tonic-textarea id="text-area-11" required="false"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>readonly="true"</span>
-    <tonic-textarea readonly="true"></tonic-textarea>
+    <tonic-textarea id="text-area-12" readonly="true"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>readonly="false"</span>
-    <tonic-textarea readonly="false"></tonic-textarea>
+    <tonic-textarea id="text-area-13" readonly="false"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>autofocus="true"</span>
-    <tonic-textarea autofocus="true"></tonic-textarea>
+    <tonic-textarea id="text-area-14" autofocus="true"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>autofocus="false"</span>
-    <tonic-textarea autofocus="false"></tonic-textarea>
+    <tonic-textarea id="text-area-15" autofocus="false"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>rows="10"</span>
-    <tonic-textarea rows="10"></tonic-textarea>
+    <tonic-textarea id="text-area-16" rows="10"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>cols="10"</span>
-    <tonic-textarea cols="10"></tonic-textarea>
+    <tonic-textarea id="text-area-17" cols="10"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>minlength="10"</span>
-    <tonic-textarea minlength="10"></tonic-textarea>
+    <tonic-textarea id="text-area-18" minlength="10"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>maxlength="100"</span>
-    <tonic-textarea maxlength="100"></tonic-textarea>
+    <tonic-textarea id="text-area-19" maxlength="100"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>width="100%"</span>
-    <tonic-textarea width="100%"></tonic-textarea>
+    <tonic-textarea id="text-area-20" width="100%"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>width="200px"</span>
-    <tonic-textarea width="100%"></tonic-textarea>
+    <tonic-textarea id="text-area-21" width="100%"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>height="300px"</span>
-    <tonic-textarea height="300px"></tonic-textarea>
+    <tonic-textarea id="text-area-22" height="300px"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>radius="10px"</span>
-    <tonic-textarea radius="10px"></tonic-textarea>
+    <tonic-textarea id="text-area-23" radius="10px"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>theme="light"</span>
-    <tonic-textarea theme="light"></tonic-textarea>
+    <tonic-textarea id="text-area-24" theme="light"></tonic-textarea>
   </div>
 
   <div class="test-container flex-half dark">
     <span>theme="dark"</span>
-    <tonic-textarea theme="dark"></tonic-textarea>
+    <tonic-textarea id="text-area-25" theme="dark"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>label="Foo Bar Bazz"</span>
-    <tonic-textarea label="Foo Bar Bazz"></tonic-textarea>
+    <tonic-textarea id="text-area-26" label="Foo Bar Bazz"></tonic-textarea>
   </div>
 
   <div class="test-container">
     <span>autofocus="true"</span>
-    <tonic-textarea autofocus="true"></tonic-textarea>
+    <tonic-textarea id="text-area-27" autofocus="true"></tonic-textarea>
   </div>
 
 </section>

--- a/toggle/index.js
+++ b/toggle/index.js
@@ -167,6 +167,15 @@ class TonicToggle extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on tonic-toggle')
+    }
+
     const {
       id,
       disabled,

--- a/toggle/index.js
+++ b/toggle/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class TonicToggle extends Tonic {
   defaults () {
     return {
@@ -167,7 +169,7 @@ class TonicToggle extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -282,6 +282,15 @@ class Windowed extends Tonic {
   }
 
   render () {
+    if (!this.props.id) {
+      console.warn('In tonic the "id" attribute is used to persist state')
+      console.warn('You forgot to supply the "id" attribute.')
+      console.warn('')
+      console.warn('For element : ')
+      console.warn(`${this.outerHTML}`)
+      throw new Error('id attribute is mandatory on windowed')
+    }
+
     if (!this.rows) {
       return this.renderLoadingState()
     }

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -1,5 +1,7 @@
 const Tonic = require('@optoolco/tonic')
 
+const mode = require('../mode')
+
 class Windowed extends Tonic {
   get length () {
     return this.rows.length
@@ -282,7 +284,7 @@ class Windowed extends Tonic {
   }
 
   render () {
-    if (!this.props.id) {
+    if (mode.strict && !this.props.id) {
       console.warn('In tonic the "id" attribute is used to persist state')
       console.warn('You forgot to supply the "id" attribute.')
       console.warn('')


### PR DESCRIPTION
The way `tonic` works is that only components that have an `id`
attribute in the HTML / DOM will have their `state` persisted
between `reRender` calls.

To improve developer experience and reduce confusion the
components that rely on `this.state` or `this.props.id` now have
their id set as mandatory in the `render()` method.

There are a few components like `tonic-textarea` that do not
have state at the moment but still have a mandatory id; this is
because they use `this.props.id` in `render()` and would actually
put `tonic--textarea_undefined` in the DOM / HTML if the `id`
is unset. This leads to duplicate `id`'s in the HTML / DOM if
you use multiple `tonic-textarea`

This is a breaking change and will require a major version
bump.