### PR TITLE
Support virtual checkbox

### DIFF
--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -42,6 +42,7 @@ label. You can also create a custom checkbox using SVG icons.
 | `color` | *string* | Changes the color of the icon. | <code>--primary</code> |
 | `tabindex` | *number* | Add a `tabindex` for the checkbox. | |
 | `theme` | *string* | Adds a theme color (`light`, `dark` or whatever is defined in your base CSS. | `light` |
+| `virtual` | *boolean* | Makes the checkbox non-clickable, you need to set the checked state manually | `false` |
 
 ### Instance Properties
 

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -78,6 +78,12 @@ class TonicCheckbox extends Tonic {
   }
 
   change (e) {
+    if (
+      this.props.virtual === true ||
+      this.props.virtual === 'true'
+    ) {
+      return
+    }
     if (this.state._changing) return
 
     e.stopPropagation()


### PR DESCRIPTION
This allows for rendering a checkbox that is not actually
manually checkable. For example you might want to render
a checkbox in a row of a table where you already have existing
logic for selecting and multi selecting rows in that table.

With a virtual checkbox you can quickly show the user that the
rows are checked or unchecked by setting `checkbox.value = bool`
whenever the rows are selected or unselected.