### PR TITLE
checkbox: Respect properties

### DIFF
--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -7,10 +7,10 @@ class TonicCheckbox extends Tonic {
     const state = this.getState()
     let value
 
-    if (typeof state.checked !== 'undefined') {
-      value = state.checked
-    } else {
+    if ('checked' in this.props) {
       value = this.props.checked
+    } else {
+      value = state.checked
     }
 
     return (value === true) || (value === 'true')
@@ -27,7 +27,6 @@ class TonicCheckbox extends Tonic {
   defaults () {
     return {
       disabled: false,
-      checked: false,
       size: '18px'
     }
   }
@@ -89,10 +88,9 @@ class TonicCheckbox extends Tonic {
 
     e.stopPropagation()
 
-    this.setState(state => Object.assign({}, state, {
-      checked: !state.checked,
-      _changing: true
-    }))
+    const currentState = this.value
+    this.state._changing = true
+    this.value = !currentState
 
     this.reRender()
   }
@@ -115,14 +113,7 @@ class TonicCheckbox extends Tonic {
   }
 
   renderIcon () {
-    let checked
-    if ('checked' in this.props) {
-      checked = (this.props.checked === true) ||
-        (this.props.checked === 'true')
-    } else {
-      checked = this.state.checked || false
-    }
-
+    const checked = this.value
     const iconState = checked ? 'checked' : 'unchecked'
 
     return this.html`
@@ -168,23 +159,9 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
+    let checked = this.value
     if (typeof this.state.checked === 'undefined') {
-      let checked = this.props.checked
-      if (checked === 'true') {
-        checked = true
-      }
-      if (checked === 'false') {
-        checked = false
-      }
       this.state.checked = checked
-    }
-
-    let checked
-    if ('checked' in this.props) {
-      checked = (this.props.checked === true) ||
-        (this.props.checked === 'true')
-    } else {
-      checked = this.state.checked || false
     }
 
     const checkedAttr = checked ? 'checked' : ''

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -114,9 +114,12 @@ class TonicCheckbox extends Tonic {
   }
 
   renderIcon () {
-    let checked = this.state.checked
-    if (typeof checked === 'undefined') {
-      checked = this.state.checked = this.props.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
+    } else {
+      checked = this.state.checked || false
     }
 
     const iconState = checked ? 'checked' : 'unchecked'
@@ -164,15 +167,12 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
-    let checked = (this.props.checked === true) || (this.props.checked === 'true')
-
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
     } else {
-      this.setState(state => Object.assign(state, {
-        state,
-        checked
-      }))
+      checked = this.state.checked || false
     }
 
     const checkedAttr = checked ? 'checked' : ''

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -20,6 +20,7 @@ class TonicCheckbox extends Tonic {
     const checked = (value === true) || (value === 'true')
 
     this.state.checked = checked
+    this.props.checked = checked
     this.reRender()
   }
 

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -167,6 +167,17 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
+    if (typeof this.state.checked === 'undefined') {
+      let checked = this.props.checked
+      if (checked === 'true') {
+        checked = true
+      }
+      if (checked === 'false') {
+        checked = false
+      }
+      this.state.checked = checked
+    }
+
     let checked
     if ('checked' in this.props) {
       checked = (this.props.checked === true) ||

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -159,7 +159,7 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
-    let checked = this.value
+    const checked = this.value
     if (typeof this.state.checked === 'undefined') {
       this.state.checked = checked
     }

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1871,8 +1871,8 @@ module.exports = { strict: false }
 class Tonic extends window.HTMLElement {
   constructor () {
     super()
-    const state = Tonic._states[this.id]
-    delete Tonic._states[this.id]
+    const state = Tonic._states[this._id]
+    delete Tonic._states[this._id]
     this.isTonicComponent = true
     this.state = state || {}
     this.props = {}
@@ -1884,13 +1884,45 @@ class Tonic extends window.HTMLElement {
   }
 
   static _createId () {
-    return Math.random().toString(16).slice(2)
+    return `tonic${Tonic._index++}`
   }
 
-  static _handleMaybePromise (p) {
+  static _maybePromise (p) {
     if (p && typeof p.then === 'function' && typeof p.catch === 'function') {
       p.catch(err => setImmediate(() => { throw err }))
     }
+  }
+
+  static _splitName (s) {
+    return s.match(/[A-Z][a-z]*/g).join('-')
+  }
+
+  static _normalizeAttrs (o, x = {}) {
+    [...o].forEach(o => (x[o.name] = o.value))
+    return x
+  }
+
+  _events () {
+    const hp = Object.getOwnPropertyNames(window.HTMLElement.prototype)
+    for (const p of this._props) {
+      if (hp.indexOf('on' + p) === -1) continue
+      this.addEventListener(p, this)
+    }
+  }
+
+  _prop (o) {
+    const id = this._id
+    const p = `__${id}__${Tonic._createId()}__`
+    Tonic._data[id] = Tonic._data[id] || {}
+    Tonic._data[id][p] = o
+    return p
+  }
+
+  _placehold (r) {
+    const ref = `__${Tonic._createId()}__`
+    Tonic._children[this._id] = Tonic._children[this._id] || {}
+    Tonic._children[this._id][ref] = r
+    return ref
   }
 
   static match (el, s) {
@@ -1898,8 +1930,17 @@ class Tonic extends window.HTMLElement {
     return el.matches(s) ? el : el.closest(s)
   }
 
+  static getPropertyNames (proto) {
+    const props = []
+    while (proto && proto !== Tonic.prototype) {
+      props.push(...Object.getOwnPropertyNames(proto))
+      proto = Object.getPrototypeOf(proto)
+    }
+    return props
+  }
+
   static add (c) {
-    c.prototype._props = Object.getOwnPropertyNames(c.prototype)
+    c.prototype._props = Tonic.getPropertyNames(c.prototype)
 
     if (!c.name || c.name.length === 1) {
       throw Error('Mangling. https://bit.ly/2TkJ6zP')
@@ -1916,7 +1957,7 @@ class Tonic extends window.HTMLElement {
   static sanitize (o) {
     if (!o) return o
     for (const [k, v] of Object.entries(o)) {
-      if (({}).toString.call(v) === '[object HTMLElement]') continue
+      if (Object.prototype.toString.call(v) === '[object HTMLElement]') continue
       if (typeof v === 'object') o[k] = Tonic.sanitize(v)
       if (typeof v === 'string') o[k] = Tonic.escape(v)
     }
@@ -1927,25 +1968,17 @@ class Tonic extends window.HTMLElement {
     return s.replace(Tonic.ESC, c => Tonic.MAP[c])
   }
 
-  static _splitName (s) {
-    return s.match(/[A-Z][a-z]*/g).join('-')
-  }
-
-  static _normalizeAttrs (o, x = {}) {
-    [...o].forEach(o => (x[o.name] = o.value))
-    return x
-  }
-
   html ([s, ...strings], ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)
-      switch (({}).toString.call(o)) {
+      switch (Object.prototype.toString.call(o)) {
         case '[object HTMLCollection]':
         case '[object NodeList]': return this._placehold([...o])
         case '[object Array]':
         case '[object Object]':
         case '[object Function]': return this._prop(o)
-        case '[object NamedNodeMap]': return this._prop(Tonic._normalizeAttrs(o))
+        case '[object NamedNodeMap]':
+          return this._prop(Tonic._normalizeAttrs(o))
         case '[object Number]': return `${o}__float`
         case '[object Boolean]': return `${o}__boolean`
         case '[object HTMLElement]':
@@ -1953,6 +1986,7 @@ class Tonic extends window.HTMLElement {
       }
       return o
     }
+
     const reduce = (a, b) => a.concat(b, strings.shift())
     return values.map(refs).reduce(reduce, [s]).join('')
   }
@@ -1965,18 +1999,28 @@ class Tonic extends window.HTMLElement {
     return this.state
   }
 
+  scheduleReRender (oldProps) {
+    if (this.pendingReRender) return this.pendingReRender
+
+    this.pendingReRender = new Promise(resolve => {
+      window.requestAnimationFrame(() => {
+        Tonic._maybePromise(this._set(this.root, this.render))
+
+        if (this.updated) this.updated(oldProps)
+
+        this.pendingReRender = null
+        resolve()
+      })
+    })
+
+    return this.pendingReRender
+  }
+
   reRender (o = this.props) {
     const oldProps = { ...this.props }
     this.props = Tonic.sanitize(typeof o === 'function' ? o(this.props) : o)
 
-    return new Promise(resolve => window.requestAnimationFrame(() => {
-      this._set(this, this.render)
-
-      if (this.updated) {
-        this.updated(oldProps)
-      }
-      resolve()
-    }))
+    return this.scheduleReRender(oldProps)
   }
 
   getProps () {
@@ -1985,15 +2029,7 @@ class Tonic extends window.HTMLElement {
 
   handleEvent (e) {
     const p = this[e.type](e)
-    Tonic._handleMaybePromise(p)
-  }
-
-  _events () {
-    const hp = Object.getOwnPropertyNames(window.HTMLElement.prototype)
-    for (const p of this._props) {
-      if (hp.indexOf('on' + p) === -1) continue
-      this.addEventListener(p, this)
-    }
+    Tonic._maybePromise(p)
   }
 
   async _set (target, render, content = '') {
@@ -2070,21 +2106,6 @@ class Tonic extends window.HTMLElement {
     }
   }
 
-  _prop (o) {
-    const id = this._id
-    const p = `__${id}__${Tonic._createId()}__`
-    Tonic._data[id] = Tonic._data[id] || {}
-    Tonic._data[id][p] = o
-    return p
-  }
-
-  _placehold (r) {
-    const ref = `__${Tonic._createId()}__`
-    Tonic._children[this._id] = Tonic._children[this._id] || {}
-    Tonic._children[this._id][ref] = r
-    return ref
-  }
-
   connectedCallback () {
     this.root = this.shadowRoot || this
 
@@ -2116,23 +2137,21 @@ class Tonic extends window.HTMLElement {
       (this.defaults && this.defaults()) || {},
       Tonic.sanitize(this.props))
 
-    if (!this._id) {
-      this.source = this.innerHTML
+    if (!this._source) {
+      this._source = this.innerHTML
     } else {
-      this.innerHTML = this.source
+      this.innerHTML = this._source
     }
 
     this._id = this._id || Tonic._createId()
 
     this.willConnect && this.willConnect()
-    this._set(this, this.render)
-    const p = (this.connected && this.connected())
-    Tonic._handleMaybePromise(p)
+    Tonic._maybePromise(this._set(this.root, this.render))
+    Tonic._maybePromise(this.connected && this.connected())
   }
 
   disconnectedCallback () {
-    const p = (this.disconnected && this.disconnected())
-    Tonic._handleMaybePromise(p)
+    Tonic._maybePromise(this.disconnected && this.disconnected())
     this.elements.length = 0
     this.nodes.length = 0
     delete Tonic._data[this._id]

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -859,9 +859,12 @@ class TonicCheckbox extends Tonic {
   }
 
   renderIcon () {
-    let checked = this.state.checked
-    if (typeof checked === 'undefined') {
-      checked = this.state.checked = this.props.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
+    } else {
+      checked = this.state.checked || false
     }
 
     const iconState = checked ? 'checked' : 'unchecked'
@@ -909,15 +912,12 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
-    let checked = (this.props.checked === true) || (this.props.checked === 'true')
-
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
     } else {
-      this.setState(state => Object.assign(state, {
-        state,
-        checked
-      }))
+      checked = this.state.checked || false
     }
 
     const checkedAttr = checked ? 'checked' : ''

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,6 +67,11 @@
   
 
     <li>
+      <a href="#api" class="">API</a>
+    </li>
+  
+
+    <li>
       <a href="#1.-getting-started" class="">1. Getting Started</a>
     </li>
   
@@ -110,11 +115,6 @@
       <a href="#9.-csp" class="">9. CSP</a>
     </li>
   
-
-    <li>
-      <a href="#api" class="">API</a>
-    </li>
-  
           </ul>
 
         </nav>
@@ -152,7 +152,7 @@
   </div>
 </div>
 
-<p><span class="status" data-before="current version" data-after="10.1.3"></span></p>
+<p><span class="status" data-before="current version" data-after="10.1.7"></span></p>
 <div class="row">
   <h3>Features</h3>
   <div class="col">
@@ -170,6 +170,142 @@
     </ul>
   </div>
 </div>
+
+    </section>
+  
+
+    <section id="api">
+      
+      <h1 id="apis">APIs</h1>
+<h2>STATIC METHODS</h2>
+<table>
+<thead>
+<tr>
+<th align="left">Method</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>add(Class)</code></td>
+<td align="left">Register a class as a new custom-tag and provide options for it.</td>
+</tr>
+<tr>
+<td align="left"><code>init(root?)</code></td>
+<td align="left">Initialize all components (optionally starating at a root node in the DOM). This is called automatically when an <App></App> component is added.</td>
+</tr>
+<tr>
+<td align="left"><code>escape(String)</code></td>
+<td align="left">Escapes HTML characters from a string (based on <a href="https://github.com/mathiasbynens/he">he</a>).</td>
+</tr>
+<tr>
+<td align="left"><code>sanitize(Object)</code></td>
+<td align="left">Escapes all the strings found in an object literal.</td>
+</tr>
+<tr>
+<td align="left"><code>match(Node, Selector)</code></td>
+<td align="left">Match the given node against a selector or any matching parent of the given node. This is useful when trying to locate a node from the actual node that was interacted with.</td>
+</tr>
+</tbody></table>
+<h2>INSTANCE METHODS</h2>
+<table>
+<thead>
+<tr>
+<th align="left">Method</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>reRender(Object &#124; Function)</code></td>
+<td align="left">Set the properties of a component instance. Can also take a function which will receive the current props as an argument.</td>
+</tr>
+<tr>
+<td align="left"><code>getProps()</code></td>
+<td align="left">Get the properties of a component instance.</td>
+</tr>
+<tr>
+<td align="left"><code>setState(Object &#124; Function)</code></td>
+<td align="left">Set the state of a component instance. Can also take a function which will receive the current props as an argument.</td>
+</tr>
+<tr>
+<td align="left">html`...`</td>
+<td align="left">Interpolated HTML string (use as a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals">tagged template</a>).</td>
+</tr>
+</tbody></table>
+<h2>INSTANCE METHODS IMPLEMENTED BY THE DEVELOPER</h2>
+<table>
+<thead>
+<tr>
+<th align="left">Name</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>stylesheet()</code></td>
+<td align="left">Should return a string of css to be lazily added to a <code>style</code> tag in the head.</td>
+</tr>
+<tr>
+<td align="left"><code>styles()</code></td>
+<td align="left">Should return an object that represents inline-styles to be applied to the component. Styles are applied by adding a keys from the object to the <code>styles</code> attribute of an html tag in the render function, for example <code>styles=&quot;key1 key2&quot;</code>. Each object&#39;s key-value pair are added to the element&#39;s style object.</td>
+</tr>
+<tr>
+<td align="left"><code>render()</code></td>
+<td align="left">Required, should return HTML or nodes to be parsed or a dom node that will overwrite. There is usually no need to call this directly, prefer <code>foo.reRender({ ... })</code>. This function can be async or an async generator.</td>
+</tr>
+</tbody></table>
+<h2>INSTANCE PROPERTIES</h2>
+<table>
+<thead>
+<tr>
+<th align="left">Name</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>elements</code></td>
+<td align="left">An array of the original child <em>elements</em> of the component.</td>
+</tr>
+<tr>
+<td align="left"><code>nodes</code></td>
+<td align="left">An array of the original child <em>nodes</em> of the component.</td>
+</tr>
+<tr>
+<td align="left"><code>props</code></td>
+<td align="left">An object that contains the properties that were passed to the component.</td>
+</tr>
+<tr>
+<td align="left"><code>state</code></td>
+<td align="left">A plain-old JSON object that contains the state of the component.</td>
+</tr>
+</tbody></table>
+<h2>&quot;LIFECYCLE&quot; INSTANCE METHODS</h2>
+<table>
+<thead>
+<tr>
+<th align="left">Method</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody><tr>
+<td align="left"><code>constructor(object)</code></td>
+<td align="left">An instance of the element is created or upgraded. Useful for initializing state, setting up event listeners, or creating shadow dom. See the spec for restrictions on what you can do in the constructor. The constructor&#39;s arguments must be forwarded by calling <code>super(object)</code>.</td>
+</tr>
+<tr>
+<td align="left"><code>willConnect()</code></td>
+<td align="left">Called prior to the element being inserted into the DOM. Useful for updating configuration, state and preparing for the render.</td>
+</tr>
+<tr>
+<td align="left"><code>connected()</code></td>
+<td align="left">Called every time the element is inserted into the DOM. Useful for running setup code, such as fetching resources or rendering. Generally, you should try to delay work until this time.</td>
+</tr>
+<tr>
+<td align="left"><code>disconnected()</code></td>
+<td align="left">Called every time the element is removed from the DOM. Useful for running clean up code.</td>
+</tr>
+<tr>
+<td align="left"><code>updated(oldProps)</code></td>
+<td align="left">Called after reRender() is called. This method is not called on the initial render.</td>
+</tr>
+</tbody></table>
 
     </section>
   
@@ -618,142 +754,6 @@ to set the <code>Tonic.nonce</code> property. For example, given the above polic
 add the following to your javascript...</p>
 <pre><code class="language-js">Tonic.nonce = <span class="hljs-string">'123'</span></code></pre>
 <p>Note that <code>123</code> is a placeholder, this should be an actual <a href="https://en.wikipedia.org/wiki/Cryptographic_nonce">nonce</a>.</p>
-
-    </section>
-  
-
-    <section id="api">
-      
-      <h1 id="apis">APIs</h1>
-<h2>STATIC METHODS</h2>
-<table>
-<thead>
-<tr>
-<th align="left">Method</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>add(Class)</code></td>
-<td align="left">Register a class as a new custom-tag and provide options for it.</td>
-</tr>
-<tr>
-<td align="left"><code>init(root?)</code></td>
-<td align="left">Initialize all components (optionally starating at a root node in the DOM). This is called automatically when an <App></App> component is added.</td>
-</tr>
-<tr>
-<td align="left"><code>escape(String)</code></td>
-<td align="left">Escapes HTML characters from a string (based on <a href="https://github.com/mathiasbynens/he">he</a>).</td>
-</tr>
-<tr>
-<td align="left"><code>sanitize(Object)</code></td>
-<td align="left">Escapes all the strings found in an object literal.</td>
-</tr>
-<tr>
-<td align="left"><code>match(Node, Selector)</code></td>
-<td align="left">Match the given node against a selector or any matching parent of the given node. This is useful when trying to locate a node from the actual node that was interacted with.</td>
-</tr>
-</tbody></table>
-<h2>INSTANCE METHODS</h2>
-<table>
-<thead>
-<tr>
-<th align="left">Method</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>reRender(Object &#124; Function)</code></td>
-<td align="left">Set the properties of a component instance. Can also take a function which will receive the current props as an argument.</td>
-</tr>
-<tr>
-<td align="left"><code>getProps()</code></td>
-<td align="left">Get the properties of a component instance.</td>
-</tr>
-<tr>
-<td align="left"><code>setState(Object &#124; Function)</code></td>
-<td align="left">Set the state of a component instance. Can also take a function which will receive the current props as an argument.</td>
-</tr>
-<tr>
-<td align="left">html`...`</td>
-<td align="left">Interpolated HTML string (use as a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals">tagged template</a>).</td>
-</tr>
-</tbody></table>
-<h2>INSTANCE METHODS IMPLEMENTED BY THE DEVELOPER</h2>
-<table>
-<thead>
-<tr>
-<th align="left">Name</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>stylesheet()</code></td>
-<td align="left">Should return a string of css to be lazily added to a <code>style</code> tag in the head.</td>
-</tr>
-<tr>
-<td align="left"><code>styles()</code></td>
-<td align="left">Should return an object that represents inline-styles to be applied to the component. Styles are applied by adding a keys from the object to the <code>styles</code> attribute of an html tag in the render function, for example <code>styles=&quot;key1 key2&quot;</code>. Each object&#39;s key-value pair are added to the element&#39;s style object.</td>
-</tr>
-<tr>
-<td align="left"><code>render()</code></td>
-<td align="left">Required, should return HTML or nodes to be parsed or a dom node that will overwrite. There is usually no need to call this directly, prefer <code>foo.reRender({ ... })</code>. This function can be async or an async generator.</td>
-</tr>
-</tbody></table>
-<h2>INSTANCE PROPERTIES</h2>
-<table>
-<thead>
-<tr>
-<th align="left">Name</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>elements</code></td>
-<td align="left">An array of the original child <em>elements</em> of the component.</td>
-</tr>
-<tr>
-<td align="left"><code>nodes</code></td>
-<td align="left">An array of the original child <em>nodes</em> of the component.</td>
-</tr>
-<tr>
-<td align="left"><code>props</code></td>
-<td align="left">An object that contains the properties that were passed to the component.</td>
-</tr>
-<tr>
-<td align="left"><code>state</code></td>
-<td align="left">A plain-old JSON object that contains the state of the component.</td>
-</tr>
-</tbody></table>
-<h2>&quot;LIFECYCLE&quot; INSTANCE METHODS</h2>
-<table>
-<thead>
-<tr>
-<th align="left">Method</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td align="left"><code>constructor(object)</code></td>
-<td align="left">An instance of the element is created or upgraded. Useful for initializing state, setting up event listeners, or creating shadow dom. See the spec for restrictions on what you can do in the constructor. The constructor&#39;s arguments must be forwarded by calling <code>super(object)</code>.</td>
-</tr>
-<tr>
-<td align="left"><code>willConnect()</code></td>
-<td align="left">Called prior to the element being inserted into the DOM. Useful for updating configuration, state and preparing for the render.</td>
-</tr>
-<tr>
-<td align="left"><code>connected()</code></td>
-<td align="left">Called every time the element is inserted into the DOM. Useful for running setup code, such as fetching resources or rendering. Generally, you should try to delay work until this time.</td>
-</tr>
-<tr>
-<td align="left"><code>disconnected()</code></td>
-<td align="left">Called every time the element is removed from the DOM. Useful for running clean up code.</td>
-</tr>
-<tr>
-<td align="left"><code>updated(oldProps)</code></td>
-<td align="left">Called after reRender() is called. This method is not called on the initial render.</td>
-</tr>
-</tbody></table>
 
     </section>
   

--- a/docs/test.js
+++ b/docs/test.js
@@ -1135,9 +1135,12 @@ class TonicCheckbox extends Tonic {
   }
 
   renderIcon () {
-    let checked = this.state.checked
-    if (typeof checked === 'undefined') {
-      checked = this.state.checked = this.props.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
+    } else {
+      checked = this.state.checked || false
     }
 
     const iconState = checked ? 'checked' : 'unchecked'
@@ -1185,15 +1188,12 @@ class TonicCheckbox extends Tonic {
       tabindex
     } = this.props
 
-    let checked = (this.props.checked === true) || (this.props.checked === 'true')
-
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
+    let checked
+    if ('checked' in this.props) {
+      checked = (this.props.checked === true) ||
+        (this.props.checked === 'true')
     } else {
-      this.setState(state => Object.assign(state, {
-        state,
-        checked
-      }))
+      checked = this.state.checked || false
     }
 
     const checkedAttr = checked ? 'checked' : ''

--- a/docs/test.js
+++ b/docs/test.js
@@ -2721,8 +2721,8 @@ module.exports = { strict: false }
 class Tonic extends window.HTMLElement {
   constructor () {
     super()
-    const state = Tonic._states[this.id]
-    delete Tonic._states[this.id]
+    const state = Tonic._states[this._id]
+    delete Tonic._states[this._id]
     this.isTonicComponent = true
     this.state = state || {}
     this.props = {}
@@ -2734,13 +2734,45 @@ class Tonic extends window.HTMLElement {
   }
 
   static _createId () {
-    return Math.random().toString(16).slice(2)
+    return `tonic${Tonic._index++}`
   }
 
-  static _handleMaybePromise (p) {
+  static _maybePromise (p) {
     if (p && typeof p.then === 'function' && typeof p.catch === 'function') {
       p.catch(err => setImmediate(() => { throw err }))
     }
+  }
+
+  static _splitName (s) {
+    return s.match(/[A-Z][a-z]*/g).join('-')
+  }
+
+  static _normalizeAttrs (o, x = {}) {
+    [...o].forEach(o => (x[o.name] = o.value))
+    return x
+  }
+
+  _events () {
+    const hp = Object.getOwnPropertyNames(window.HTMLElement.prototype)
+    for (const p of this._props) {
+      if (hp.indexOf('on' + p) === -1) continue
+      this.addEventListener(p, this)
+    }
+  }
+
+  _prop (o) {
+    const id = this._id
+    const p = `__${id}__${Tonic._createId()}__`
+    Tonic._data[id] = Tonic._data[id] || {}
+    Tonic._data[id][p] = o
+    return p
+  }
+
+  _placehold (r) {
+    const ref = `__${Tonic._createId()}__`
+    Tonic._children[this._id] = Tonic._children[this._id] || {}
+    Tonic._children[this._id][ref] = r
+    return ref
   }
 
   static match (el, s) {
@@ -2748,8 +2780,17 @@ class Tonic extends window.HTMLElement {
     return el.matches(s) ? el : el.closest(s)
   }
 
+  static getPropertyNames (proto) {
+    const props = []
+    while (proto && proto !== Tonic.prototype) {
+      props.push(...Object.getOwnPropertyNames(proto))
+      proto = Object.getPrototypeOf(proto)
+    }
+    return props
+  }
+
   static add (c) {
-    c.prototype._props = Object.getOwnPropertyNames(c.prototype)
+    c.prototype._props = Tonic.getPropertyNames(c.prototype)
 
     if (!c.name || c.name.length === 1) {
       throw Error('Mangling. https://bit.ly/2TkJ6zP')
@@ -2766,7 +2807,7 @@ class Tonic extends window.HTMLElement {
   static sanitize (o) {
     if (!o) return o
     for (const [k, v] of Object.entries(o)) {
-      if (({}).toString.call(v) === '[object HTMLElement]') continue
+      if (Object.prototype.toString.call(v) === '[object HTMLElement]') continue
       if (typeof v === 'object') o[k] = Tonic.sanitize(v)
       if (typeof v === 'string') o[k] = Tonic.escape(v)
     }
@@ -2777,25 +2818,17 @@ class Tonic extends window.HTMLElement {
     return s.replace(Tonic.ESC, c => Tonic.MAP[c])
   }
 
-  static _splitName (s) {
-    return s.match(/[A-Z][a-z]*/g).join('-')
-  }
-
-  static _normalizeAttrs (o, x = {}) {
-    [...o].forEach(o => (x[o.name] = o.value))
-    return x
-  }
-
   html ([s, ...strings], ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)
-      switch (({}).toString.call(o)) {
+      switch (Object.prototype.toString.call(o)) {
         case '[object HTMLCollection]':
         case '[object NodeList]': return this._placehold([...o])
         case '[object Array]':
         case '[object Object]':
         case '[object Function]': return this._prop(o)
-        case '[object NamedNodeMap]': return this._prop(Tonic._normalizeAttrs(o))
+        case '[object NamedNodeMap]':
+          return this._prop(Tonic._normalizeAttrs(o))
         case '[object Number]': return `${o}__float`
         case '[object Boolean]': return `${o}__boolean`
         case '[object HTMLElement]':
@@ -2803,6 +2836,7 @@ class Tonic extends window.HTMLElement {
       }
       return o
     }
+
     const reduce = (a, b) => a.concat(b, strings.shift())
     return values.map(refs).reduce(reduce, [s]).join('')
   }
@@ -2815,18 +2849,28 @@ class Tonic extends window.HTMLElement {
     return this.state
   }
 
+  scheduleReRender (oldProps) {
+    if (this.pendingReRender) return this.pendingReRender
+
+    this.pendingReRender = new Promise(resolve => {
+      window.requestAnimationFrame(() => {
+        Tonic._maybePromise(this._set(this.root, this.render))
+
+        if (this.updated) this.updated(oldProps)
+
+        this.pendingReRender = null
+        resolve()
+      })
+    })
+
+    return this.pendingReRender
+  }
+
   reRender (o = this.props) {
     const oldProps = { ...this.props }
     this.props = Tonic.sanitize(typeof o === 'function' ? o(this.props) : o)
 
-    return new Promise(resolve => window.requestAnimationFrame(() => {
-      this._set(this, this.render)
-
-      if (this.updated) {
-        this.updated(oldProps)
-      }
-      resolve()
-    }))
+    return this.scheduleReRender(oldProps)
   }
 
   getProps () {
@@ -2835,15 +2879,7 @@ class Tonic extends window.HTMLElement {
 
   handleEvent (e) {
     const p = this[e.type](e)
-    Tonic._handleMaybePromise(p)
-  }
-
-  _events () {
-    const hp = Object.getOwnPropertyNames(window.HTMLElement.prototype)
-    for (const p of this._props) {
-      if (hp.indexOf('on' + p) === -1) continue
-      this.addEventListener(p, this)
-    }
+    Tonic._maybePromise(p)
   }
 
   async _set (target, render, content = '') {
@@ -2920,21 +2956,6 @@ class Tonic extends window.HTMLElement {
     }
   }
 
-  _prop (o) {
-    const id = this._id
-    const p = `__${id}__${Tonic._createId()}__`
-    Tonic._data[id] = Tonic._data[id] || {}
-    Tonic._data[id][p] = o
-    return p
-  }
-
-  _placehold (r) {
-    const ref = `__${Tonic._createId()}__`
-    Tonic._children[this._id] = Tonic._children[this._id] || {}
-    Tonic._children[this._id][ref] = r
-    return ref
-  }
-
   connectedCallback () {
     this.root = this.shadowRoot || this
 
@@ -2966,23 +2987,21 @@ class Tonic extends window.HTMLElement {
       (this.defaults && this.defaults()) || {},
       Tonic.sanitize(this.props))
 
-    if (!this._id) {
-      this.source = this.innerHTML
+    if (!this._source) {
+      this._source = this.innerHTML
     } else {
-      this.innerHTML = this.source
+      this.innerHTML = this._source
     }
 
     this._id = this._id || Tonic._createId()
 
     this.willConnect && this.willConnect()
-    this._set(this, this.render)
-    const p = (this.connected && this.connected())
-    Tonic._handleMaybePromise(p)
+    Tonic._maybePromise(this._set(this.root, this.render))
+    Tonic._maybePromise(this.connected && this.connected())
   }
 
   disconnectedCallback () {
-    const p = (this.disconnected && this.disconnected())
-    Tonic._handleMaybePromise(p)
+    Tonic._maybePromise(this.disconnected && this.disconnected())
     this.elements.length = 0
     this.nodes.length = 0
     delete Tonic._data[this._id]


### PR DESCRIPTION
When controlling a checkbox manually like for example
a "check all" checkbox that you want to keep in sync with
individual checkable items you want to set the state of whether
it's checked or not via properties.

The current implementation only allows setting the default
checked state as true or false and all future state is purely
coming from `this.state` ;

This change makes it respect the checked property and makes
the component declarative and re-render friendly by being able
to update the checked state in `render()` instead of having to
do `querySelector(checkbox).value = x` to update the checked
state.