### PR TITLE
Windowed: Improvements for streaming

### DIFF
--- a/windowed/index.js
+++ b/windowed/index.js
@@ -164,6 +164,7 @@ class Windowed extends Tonic {
 
     const inner = this.querySelector('.tonic--windowed--inner')
     inner.appendChild(page)
+    page.__overflow__ = []
     return page
   }
 
@@ -193,6 +194,7 @@ class Windowed extends Tonic {
           await this.updatePage(i)
         } else {
           page.innerHTML = ''
+          page.__overflow__ = []
           await this.fillPage(i)
         }
       }
@@ -255,6 +257,10 @@ class Windowed extends Tonic {
     for (let j = start, rowIdx = 0; j < limit; j++, rowIdx++) {
       if (page.children[rowIdx] && this.updateRow) {
         this.updateRow(await this.getRow(j), j, page.children[rowIdx])
+      } else if (page.__overflow__.length > 0 && this.updateRow) {
+        const child = page.__overflow__.shift()
+        this.updateRow(await this.getRow(j), j, child)
+        page.appendChild(child)
       } else {
         const div = document.createElement('div')
         div.innerHTML = this.renderRow(await this.getRow(j), j)
@@ -263,7 +269,9 @@ class Windowed extends Tonic {
     }
 
     while (page.children.length > limit - start) {
-      page.removeChild(page.lastChild)
+      const child = page.lastChild
+      page.__overflow__.push(child)
+      page.removeChild(child)
     }
   }
 

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -4,7 +4,7 @@ const mode = require('../mode')
 
 class Windowed extends Tonic {
   constructor (o) {
-    super (o)
+    super(o)
 
     this.prependCounter = 0
     this.currentVisibleRowIndex = -1

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -79,24 +79,30 @@ class Windowed extends Tonic {
     this.rows = rows
     await this.reRender()
 
+    const inner = this.querySelector('.tonic--windowed--inner')
+    if (inner) {
+      inner.innerHTML = ''
+    }
+
+    this.rowHeight = parseInt(this.props.rowHeight, 10)
+    this.pageHeight = this.props.rowsPerPage * this.rowHeight
+    this.padding = this.props.rowPadding * this.rowHeight
+    this.setInnerHeight()
+    return this.rePaint()
+  }
+
+  setInnerHeight () {
     const outer = this.querySelector('.tonic--windowed--outer')
     if (!outer) return
 
     this.outerHeight = outer.offsetHeight
-
     this.numPages = Math.ceil(this.rows.length / this.props.rowsPerPage)
 
-    this.pages = {}
+    this.pages = this.pages || {}
     this.pagesAvailable = this.pagesAvailable || []
-    this.rowHeight = parseInt(this.props.rowHeight, 10)
 
     const inner = this.querySelector('.tonic--windowed--inner')
-    inner.innerHTML = ''
     inner.style.height = `${this.rowHeight * this.rows.length}px`
-    this.pageHeight = this.props.rowsPerPage * this.rowHeight
-    this.padding = this.props.rowPadding * this.rowHeight
-
-    this.rePaint()
   }
 
   setHeight (height, { render } = {}) {

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -220,7 +220,7 @@ class Windowed extends Tonic {
     return `${i * this.pageHeight}px`
   }
 
-  getLastPageHeight (i) {
+  getLastPageHeight () {
     return `${(this.rows.length % this.props.rowsPerPage) * this.rowHeight}px`
   }
 


### PR DESCRIPTION
These are a collection of improvements for streaming
into a windowed component.

 - Expose setInnerHeight()
 - Recycle dom elems in __overflow__
 - Scroll back to visible elem after prepend.

r: @heapwolf