### PR TITLE
Improve windowed auto scrolling

### DIFF
--- a/form/index.js
+++ b/form/index.js
@@ -6,6 +6,8 @@ class TonicForm extends Tonic {
   }
 
   static getPropertyValue (o, path) {
+    if (!path) return null
+
     const parts = path.split('.')
     let value = o
 
@@ -18,6 +20,8 @@ class TonicForm extends Tonic {
   }
 
   static setPropertyValue (o, path, v) {
+    if (!path) return
+
     const parts = path.split('.')
     let value = o
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,9 +117,9 @@
       }
     },
     "@optoolco/tonic": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-11.0.0.tgz",
-      "integrity": "sha512-nj6U2UUGHr6lOmhcEi5nEP9vdnEc8PQX/5+X4NjA96lrkfxnyiPyrIgnfe5LHY9BX7vPLid4BOp3Ne5B8QGJ4Q==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-11.0.3.tgz",
+      "integrity": "sha512-0hDou0iEQQueM7Ej68rcqcM9WrEy4YKWwTMpN7Pl7izZt+e/GcmMAf+B06buFYkrvxxY3per9HZG4e4WM84M4A==",
       "dev": true
     },
     "@types/error-stack-parser": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/optoolco/components#readme",
   "devDependencies": {
-    "@optoolco/tonic": "11.0.0",
+    "@optoolco/tonic": "11.0.3",
     "autoprefixer-stylus": "^0.14.0",
     "beefy": "2.1.8",
     "browserify": "^16.2.2",

--- a/windowed/index.js
+++ b/windowed/index.js
@@ -78,7 +78,11 @@ class Windowed extends Tonic {
     const index = arguments[0]
     const totalItems = arguments.length - 2
 
-    if (index <= this.currentVisibleRowIndex) {
+    // If index === 0 then the user has not scrolled yet.
+    // So do not auto scroll the table. If current visible row
+    // is zero then the user just wants to look at the top
+    // of the table.
+    if (index <= this.currentVisibleRowIndex && index !== 0) {
       this.prependCounter += totalItems
       this.currentVisibleRowIndex += totalItems
     }


### PR DESCRIPTION
This was causing weird behavior for the logs app
where it starts scrolling to the "current visible" row.

Instead if the index is 0 ; aka i am looking at the top,
I should just keep looking at the top.