### PR TITLE
input: Do not relay `input` event.

### DIFF
--- a/input/index.js
+++ b/input/index.js
@@ -204,7 +204,6 @@ class TonicInput extends Tonic {
     input.addEventListener('input', e => {
       set('value', e.target.value)
       set('pos', e.target.selectionStart)
-      relay('input')
     })
 
     const state = this.getState()


### PR DESCRIPTION
On the `TonicInput` component we trigger the input event twice.

For focus & blur the `relay()` function is necessary since the
DOM `blur` & `focus` events do not bubble.

However the `input` event already bubbles so we do not have to
relay it, otherwise the outer component event listener gets
called twice and does duplicate work.