### PR TITLE
src: Fix null pointer for this.rows

### DIFF
--- a/windowed/index.js
+++ b/windowed/index.js
@@ -159,7 +159,7 @@ class Windowed extends Tonic {
       )
     }
 
-    if (this.rows.length > maxRows) {
+    if (this.rows && this.rows.length > maxRows) {
       const toDelete = this.rows.length - maxRows
 
       if (this.prefetchDirection === 'bottom') {


### PR DESCRIPTION
Ran into this issue by using `clear()` to reset a `Windowed` component and load a new Query into it.