### PR TITLE
Tabs: Emit tabshow event

### DIFF
--- a/tabs/README.md
+++ b/tabs/README.md
@@ -119,10 +119,10 @@ for the `selected` attribute on the `tonic-tabs` component.
 *for `tonic-tabs`*
 
 `tabvisible` ; event emitted when a tab becomes visible. Contains
-`ev.detail.id` for which tab is visible.
+`event.detail.id` for which tab is visible.
 
 `tabhidden` ; event emitted when a tab becomes hidden. Contains
-`ev.detail.id` for which tab is hidden.
+`event.detail.id` for which tab is hidden.
 
 The `tabvisible` & `tabhidden` events get fired whenever a tab
 is changed and get triggered both from click & keyboard events.

--- a/tabs/README.md
+++ b/tabs/README.md
@@ -113,3 +113,16 @@ for the `selected` attribute on the `tonic-tabs` component.
 | `click()` | Click event. |
 | `get value` | Get the currently selected tab. |
 | `set selected(String)` | Set the currently selected tab. |
+
+### Events
+
+*for `tonic-tabs`*
+
+`tabvisible` ; event emitted when a tab becomes visible. Contains
+`ev.detail.id` for which tab is visible.
+
+`tabhidden` ; event emitted when a tab becomes hidden. Contains
+`ev.detail.id` for which tab is hidden.
+
+The `tabvisible` & `tabhidden` events get fired whenever a tab
+is changed and get triggered both from click & keyboard events.

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -49,11 +49,14 @@ class TonicTabs extends Tonic {
         tab.setAttribute('aria-selected', 'true')
         this.state.selected = id
         this.dispatchEvent(new CustomEvent(
-          'tabshow', { detail: { id }, bubbles: true }
+          'tabvisible', { detail: { id }, bubbles: true }
         ))
       } else {
         panel.setAttribute('hidden', '')
         tab.setAttribute('aria-selected', 'false')
+        this.dispatchEvent(new CustomEvent(
+          'tabhidden', { detail: { id }, bubbles: true }
+        ))
       }
     }
   }

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -50,6 +50,12 @@ class TonicTabs extends Tonic {
         panel.setAttribute('hidden', '')
         tab.setAttribute('aria-selected', 'false')
       }
+
+      if (panel.firstElementChild &&
+          panel.firstElementChild.onTabShow
+      ) {
+        panel.firstElementChild.onTabShow()
+      }
     }
   }
 

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -2,6 +2,8 @@ const Tonic = require('@optoolco/tonic')
 
 const mode = require('../mode')
 
+const CustomEvent = window.CustomEvent
+
 class TonicTabs extends Tonic {
   static stylesheet () {
     return `
@@ -46,15 +48,12 @@ class TonicTabs extends Tonic {
         panel.removeAttribute('hidden')
         tab.setAttribute('aria-selected', 'true')
         this.state.selected = id
+        this.dispatchEvent(new CustomEvent(
+          'tabshow', { detail: { id }, bubbles: true }
+        ))
       } else {
         panel.setAttribute('hidden', '')
         tab.setAttribute('aria-selected', 'false')
-      }
-
-      if (panel.firstElementChild &&
-          panel.firstElementChild.onTabShow
-      ) {
-        panel.firstElementChild.onTabShow()
       }
     }
   }


### PR DESCRIPTION
This allows a Tonic component embedded inside a Tab to
be notified when it is made visible.

This could be implemented manually but since the Tab is toggled
both by clicks and by keyboard presses the outer component
would have to either handle both or have a buggy keyboard impl.