### PR TITLE
allow accessing tonic-form from elem

### DIFF
--- a/button/index.js
+++ b/button/index.js
@@ -6,7 +6,14 @@ class TonicButton extends Tonic {
   }
 
   get form () {
-    return this.querySelector('button').form
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
   }
 
   get disabled () {

--- a/checkbox/index.js
+++ b/checkbox/index.js
@@ -3,6 +3,17 @@ const Tonic = require('@optoolco/tonic')
 const mode = require('../mode')
 
 class TonicCheckbox extends Tonic {
+  get form () {
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+
   get value () {
     const state = this.getState()
     let value

--- a/form/test.js
+++ b/form/test.js
@@ -53,7 +53,7 @@ tape('{{form-1}} get data from form', t => {
   const inputB = qs('#b', component)
   const inputD = qs('#d', component)
 
-  t.plan(2)
+  t.plan(3)
 
   t.ok(inputA && inputB && inputD, 'the component contains the correct number of inputs')
 
@@ -66,6 +66,7 @@ tape('{{form-1}} get data from form', t => {
   }
 
   t.deepEqual(expected, component.value)
+  t.equal(inputA.form, component)
 
   t.end()
 })

--- a/input/index.js
+++ b/input/index.js
@@ -19,7 +19,14 @@ class TonicInput extends Tonic {
   }
 
   get form () {
-    return this.querySelector('input').form
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
   }
 
   get value () {

--- a/range/index.js
+++ b/range/index.js
@@ -13,6 +13,17 @@ class TonicRange extends Tonic {
     }
   }
 
+  get form () {
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+
   get value () {
     return this.state.value
   }

--- a/select/index.js
+++ b/select/index.js
@@ -10,6 +10,17 @@ class TonicSelect extends Tonic {
     }
   }
 
+  get form () {
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+
   static stylesheet () {
     return `
       tonic-select .tonic--wrapper {

--- a/textarea/index.js
+++ b/textarea/index.js
@@ -16,6 +16,17 @@ class TonicTextarea extends Tonic {
     }
   }
 
+  get form () {
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+
   static stylesheet () {
     return `
       tonic-textarea textarea {

--- a/toggle/index.js
+++ b/toggle/index.js
@@ -9,6 +9,17 @@ class TonicToggle extends Tonic {
     }
   }
 
+  get form () {
+    let el = this
+
+    do {
+      if (el.tagName === 'FORM') return el
+      if (el.tagName === 'TONIC-FORM') return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+
   get value () {
     const state = this.getState()
     let value


### PR DESCRIPTION
This is useful in a `click` event where we can access
`el.form` or `ev.target.form` to access the form
for the corresponding button.

The `tonic-form` element helps us to not query
selector every single input element in a form.

The `button.form` getter helps us to not query
selector the form in the component.