### PR TITLE
windowed: tighten check for renderLoadingX

### DIFF
--- a/windowed/index.js
+++ b/windowed/index.js
@@ -344,6 +344,7 @@ class Windowed extends Tonic {
     const totalHeight = this.rows.length * this.props.rowHeight
     if (
       viewEnd === totalHeight &&
+      this.prefetchBottom &&
       this.renderLoadingBottom &&
       !this.noMoreBottomRows
     ) {
@@ -354,6 +355,7 @@ class Windowed extends Tonic {
     if (
       this.rows.length === this.props.maxRowsLength &&
       viewStart === 0 &&
+      this.prefetchTop &&
       this.renderLoadingTop &&
       !this.noMoreTopRows
     ) {


### PR DESCRIPTION
The gaurd for rendering loading bottom & top should be a bit
more specific.

If we gaurd for the prefetch methods then the DataTable can
implement the default loading bottom & top methods irregardless
of the whether the sub class actually wants to implement prefetch