### PR TITLE
src/toggle: Make toggle re-render safe

### DIFF
--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -5741,20 +5741,14 @@ const Tonic = require('@optoolco/tonic')
 const mode = require('../mode')
 
 class TonicToggle extends Tonic {
-  defaults () {
-    return {
-      checked: false
-    }
-  }
-
   get value () {
     const state = this.getState()
     let value
 
-    if (typeof state.checked !== 'undefined') {
-      value = state.checked
-    } else {
+    if ('checked' in this.props) {
       value = this.props.checked
+    } else {
+      value = state.checked
     }
 
     return (value === true) || (value === 'true')
@@ -5762,11 +5756,10 @@ class TonicToggle extends Tonic {
 
   set value (value) {
     const checked = (value === true) || (value === 'true')
-    this.state.checked = checked
 
-    this.reRender(props => Object.assign(props, {
-      checked
-    }))
+    this.state.checked = checked
+    this.props.checked = checked
+    this.reRender()
   }
 
   static stylesheet () {
@@ -5890,9 +5883,7 @@ class TonicToggle extends Tonic {
   }
 
   change (e) {
-    this.setState(state => Object.assign({}, state, {
-      checked: e.target.checked
-    }))
+    this.state.checked = e.target.checked
   }
 
   renderLabel () {
@@ -5926,13 +5917,10 @@ class TonicToggle extends Tonic {
     if (tabindex) this.removeAttribute('tabindex')
     if (theme) this.classList.add(`tonic--theme--${theme}`)
 
-    let checked
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
-    } else {
-      checked = this.props.checked === 'true'
+    const checked = this.value
+    if (typeof this.state.checked === 'undefined') {
+      this.state.checked = checked
     }
-    this.state.checked = checked
 
     return this.html`
       <div class="tonic--toggle--wrapper">

--- a/docs/test.js
+++ b/docs/test.js
@@ -17542,20 +17542,14 @@ const Tonic = require('@optoolco/tonic')
 const mode = require('../mode')
 
 class TonicToggle extends Tonic {
-  defaults () {
-    return {
-      checked: false
-    }
-  }
-
   get value () {
     const state = this.getState()
     let value
 
-    if (typeof state.checked !== 'undefined') {
-      value = state.checked
-    } else {
+    if ('checked' in this.props) {
       value = this.props.checked
+    } else {
+      value = state.checked
     }
 
     return (value === true) || (value === 'true')
@@ -17563,11 +17557,10 @@ class TonicToggle extends Tonic {
 
   set value (value) {
     const checked = (value === true) || (value === 'true')
-    this.state.checked = checked
 
-    this.reRender(props => Object.assign(props, {
-      checked
-    }))
+    this.state.checked = checked
+    this.props.checked = checked
+    this.reRender()
   }
 
   static stylesheet () {
@@ -17691,9 +17684,7 @@ class TonicToggle extends Tonic {
   }
 
   change (e) {
-    this.setState(state => Object.assign({}, state, {
-      checked: e.target.checked
-    }))
+    this.state.checked = e.target.checked
   }
 
   renderLabel () {
@@ -17727,13 +17718,10 @@ class TonicToggle extends Tonic {
     if (tabindex) this.removeAttribute('tabindex')
     if (theme) this.classList.add(`tonic--theme--${theme}`)
 
-    let checked
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
-    } else {
-      checked = this.props.checked === 'true'
+    const checked = this.value
+    if (typeof this.state.checked === 'undefined') {
+      this.state.checked = checked
     }
-    this.state.checked = checked
 
     return this.html`
       <div class="tonic--toggle--wrapper">

--- a/toggle/index.js
+++ b/toggle/index.js
@@ -3,20 +3,14 @@ const Tonic = require('@optoolco/tonic')
 const mode = require('../mode')
 
 class TonicToggle extends Tonic {
-  defaults () {
-    return {
-      checked: false
-    }
-  }
-
   get value () {
     const state = this.getState()
     let value
 
-    if (typeof state.checked !== 'undefined') {
-      value = state.checked
-    } else {
+    if ('checked' in this.props) {
       value = this.props.checked
+    } else {
+      value = state.checked
     }
 
     return (value === true) || (value === 'true')
@@ -24,11 +18,10 @@ class TonicToggle extends Tonic {
 
   set value (value) {
     const checked = (value === true) || (value === 'true')
-    this.state.checked = checked
 
-    this.reRender(props => Object.assign(props, {
-      checked
-    }))
+    this.state.checked = checked
+    this.props.checked = checked
+    this.reRender()
   }
 
   static stylesheet () {
@@ -152,9 +145,7 @@ class TonicToggle extends Tonic {
   }
 
   change (e) {
-    this.setState(state => Object.assign({}, state, {
-      checked: e.target.checked
-    }))
+    this.state.checked = e.target.checked
   }
 
   renderLabel () {
@@ -188,13 +179,10 @@ class TonicToggle extends Tonic {
     if (tabindex) this.removeAttribute('tabindex')
     if (theme) this.classList.add(`tonic--theme--${theme}`)
 
-    let checked
-    if (typeof this.state.checked !== 'undefined') {
-      checked = this.state.checked
-    } else {
-      checked = this.props.checked === 'true'
+    const checked = this.value
+    if (typeof this.state.checked === 'undefined') {
+      this.state.checked = checked
     }
-    this.state.checked = checked
 
     return this.html`
       <div class="tonic--toggle--wrapper">


### PR DESCRIPTION
Currently toggle does not respect `checked={true|false}` on subsequent
re-renders.

This PR is very similar to https://github.com/optoolco/components/pull/43

Toggle will now respect the properties upon reRender instead of treating
the `checked` value as an "initial value"