### PR TITLE
chart: Support bundling of tonic-chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -5,6 +5,7 @@ An example component that uses [chart.js][0] `2.8.0`.
   type="horizontalBar"
   width="300px"
   height="150px"
+  chart-library="${require('chart.js')}"
   src="/chartdata.json">
 </tonic-chart>
 
@@ -31,7 +32,8 @@ const opts = {
   type="horizontalBar"
   width="300"
   height="150px"
-  options=${opts}
+  options="${opts}"
+  chart-library="${require('chart.js')}"
   src="/chartdata.json">
 </tonic-chart>
 ```
@@ -57,6 +59,7 @@ const opts = {
 | :--- | :--- | :--- | :--- |
 | `title` | *string* | The title of the chart. | |
 | `type` | *string* | The type of the bar chart. | |
+| `chart-library` | *function* | The `require('chart.js')` module | |
 | `src` | *object* or *string* | The data for the chart. A url or an object. | |
 | `tooltip` | *bool* | Show or don't show the tooltip. | |
 | `width` | *string* | Width of the chart (include the unit, `%`, `px` etc). | |
@@ -67,5 +70,6 @@ const opts = {
 | Method | Description |
 | :--- | :--- |
 | `draw(Object, Object)` | Draws (or re-draws) the chart. The first parameter is the data and the second is options. |
+| `setChart(Function)` | Sets the chart library; call with `setChart(require('chart.js))`. This is an alternative to the `chart-library` HTML attribute |
 
 [0]:https://www.chartjs.org/

--- a/chart/index.js
+++ b/chart/index.js
@@ -1,17 +1,6 @@
 const Tonic = require('@optoolco/tonic')
 
 class TonicChart extends Tonic {
-  constructor (o) {
-    super(o)
-
-    try {
-      const dynamicRequire = require
-      this.Chart = dynamicRequire('chart.js')
-    } catch (err) {
-      console.error('could not find "chart.js" dependency. npm install?')
-    }
-  }
-
   static stylesheet () {
     return `
       tonic-chart {
@@ -24,6 +13,10 @@ class TonicChart extends Tonic {
         position: relative;
       }
     `
+  }
+
+  setChart (Chart) {
+    this.Chart = Chart
   }
 
   draw (data = {}, options = {}) {
@@ -50,6 +43,12 @@ class TonicChart extends Tonic {
 
   async connected () {
     let data = null
+
+    if (this.props.chartLibrary) {
+      this.Chart = this.props.chartLibrary
+    }
+
+    if (!this.Chart) return
 
     const options = {
       ...this.props,

--- a/chart/test.js
+++ b/chart/test.js
@@ -5,13 +5,39 @@ const { html } = require('../test/util')
 const components = require('..')
 components(require('@optoolco/tonic'))
 
+// const CHART_OPTS = {
+//   tooltips: {
+//     enabled: false
+//   },
+//   legend: {
+//     display: false
+//   },
+//   drawTicks: true,
+//   drawBorder: true
+// }
+
+const CHART_DATA = {
+  labels: ['Foo', 'Bar', 'Bazz'],
+  datasets: [{
+    label: 'Quxx (millions)',
+    backgroundColor: ['#c3c3c3', '#f06653', '#8f8f8f'],
+    data: [278, 467, 34]
+  }]
+}
+
 document.body.appendChild(html`
 <section id="chart">
   <h2>Chart</h2>
 
   <div id="chart-1" class="test-container">
     <span>Default</span>
-    <tonic-chart width=400px height=400px></tonic-chart>
+    <tonic-chart
+      type="horizontalBar"
+      width=400px
+      height=400px
+      src="${CHART_DATA}"
+      chart-library="${require('chart.js')}"
+    ></tonic-chart>
   </div>
 </section>
 `)
@@ -29,7 +55,8 @@ tape('got a chart', t => {
   t.equal(canvas.height, 400)
 
   const styles = window.getComputedStyle(canvas)
-  t.equal(styles.display, 'inline-block')
+  t.equal(styles.display, 'block')
+  t.equal(canvas.getAttribute('class'), 'chartjs-render-monitor')
 
   t.end()
 })


### PR DESCRIPTION
The tonic-chart component currently uses dynamicRequire to
load the chart.js library.

This confuses the bundling tooling like `noderify` which means
that the `tonic-chart` component works in our electron app EXCEPT
when we bundle it into a package app binary with an `app.asar`.

By passing the `require('chart.js')` library as either a HTML
attribute or as a `setChart()` method we can require the `chart.js`
library in our app, have that picked up by the bundler without
a dynamic require statement and have the `tonic-chart` working
in the packaged version of our app.