### PR TITLE
src/windowed: Bail if scrolling to stale id.

### DIFF
--- a/windowed/index.js
+++ b/windowed/index.js
@@ -256,9 +256,7 @@ class Windowed extends Tonic {
    */
   scrollToId (offsetId) {
     const index = this.rows.findIndex(o => o.id === offsetId)
-    if (index === -1) {
-      throw new Error('offsetId does not exist in this.rows')
-    }
+    if (typeof index !== 'number') return
     if (this.rowHeight === null) {
       throw new Error('Cannot call scrollToId() before load()')
     }


### PR DESCRIPTION
Do not throw an error if the user requested to scroll to an
id that is no longer in `this.rows`;