### PR TITLE
tabs: Reduce amount of work done by default

### DIFF
--- a/input/test.js
+++ b/input/test.js
@@ -29,7 +29,6 @@ class InputWrapper extends Tonic {
   }
 
   click (ev) {
-    console.log('click ev')
     const el = Tonic.match(ev.target, '[data-event]')
     if (!el || el.dataset.event !== 'copy') return
 
@@ -397,11 +396,11 @@ tape('input wrapper component interactions', t => {
 
   buttons[0].click()
 
-  requestAnimationFrame(() => {
+  setTimeout(() => {
     display = comp.querySelector('span.display')
     t.equal(display.textContent, 'someText')
     t.equal(comp.state.inputEvents, 1)
 
     t.end()
-  })
+  }, 20)
 })

--- a/input/test.js
+++ b/input/test.js
@@ -6,8 +6,6 @@ const components = require('..')
 const Tonic = require('@optoolco/tonic')
 components(Tonic)
 
-const requestAnimationFrame = window.requestAnimationFrame
-
 class InputWrapper extends Tonic {
   constructor (o) {
     super(o)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "testcafe": "1.6.1"
   },
   "devDependencies": {
-    "@optoolco/tonic": "github:optoolco/tonic#a940798b13d2dcfd1c3fe1f4725674b08abee08b",
+    "@optoolco/tonic": "12.0.2",
     "@pre-bundled/send": "0.16.2-patch-1",
     "@pre-bundled/tape": "4.11.0",
     "chart.js": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "testcafe": "1.6.1"
   },
   "devDependencies": {
-    "@optoolco/tonic": "12.0.0",
+    "@optoolco/tonic": "github:optoolco/tonic#a940798b13d2dcfd1c3fe1f4725674b08abee08b",
     "@pre-bundled/send": "0.16.2-patch-1",
     "@pre-bundled/tape": "4.11.0",
     "chart.js": "^2.9.2",

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -82,7 +82,10 @@ class TonicTabs extends Tonic {
 
         if (!panel.parentElement) {
           panelStore.parent.appendChild(panel)
-          if (panel.preventRenderOnReconnect && panel.reRender) {
+          if (
+            panel.preventRenderOnReconnect && panel.reRender &&
+            panel.children.length === 0
+          ) {
             await panel.reRender()
           }
         }

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -37,6 +37,7 @@ class TonicTabs extends Tonic {
   }
 
   async setVisibility (id, forAttr) {
+    const renderAll = this.props.renderAll === 'true'
     const tabs = this.querySelectorAll('tonic-tab')
 
     for (const tab of tabs) {
@@ -91,8 +92,15 @@ class TonicTabs extends Tonic {
           'tabvisible', { detail: { id }, bubbles: true }
         ))
       } else {
+        if (!panel.visible && renderAll) {
+          panel.visible = true
+          if (panel.parentElement && panel.reRender) {
+            await panel.reRender()
+          }
+        }
+
         panel.setAttribute('hidden', '')
-        if (panel.parentElement) {
+        if (panel.parentElement && !renderAll) {
           this.panels[panel.id] = {
             parent: panel.parentElement,
             node: panel

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -36,7 +36,7 @@ class TonicTabs extends Tonic {
     this.panels = this.panels || {}
   }
 
-  setVisibility (id, forAttr) {
+  async setVisibility (id, forAttr) {
     const tabs = this.querySelectorAll('tonic-tab')
 
     for (const tab of tabs) {
@@ -75,12 +75,15 @@ class TonicTabs extends Tonic {
         if (!panel.visible) {
           panel.visible = true
           if (panel.parentElement && panel.reRender) {
-            panel.reRender()
+            await panel.reRender()
           }
         }
 
         if (!panel.parentElement) {
           panelStore.parent.appendChild(panel)
+          if (panel.preventRenderOnReconnect && panel.reRender) {
+            await panel.reRender()
+          }
         }
 
         this.state.selected = id
@@ -176,6 +179,7 @@ class TonicTabPanel extends Tonic {
     super(o)
 
     this.visible = this.visible || false
+    this.__originalChildren = this.nodes
 
     if (!this.visible) {
       this.setAttribute('hidden', '')
@@ -200,7 +204,7 @@ class TonicTabPanel extends Tonic {
   render () {
     // console.trace('TabPanel.render()', this.id, this.visible)
     if (this.visible) {
-      return this.html`${this.childNodes}`
+      return this.html`${this.__originalChildren}`
     }
     return ''
   }

--- a/tabs/index.js
+++ b/tabs/index.js
@@ -6,6 +6,7 @@ class TonicTabs extends Tonic {
   constructor (o) {
     super(o)
 
+    this._setVisibilitySynchronously = false
     this.panels = {}
   }
 
@@ -31,6 +32,10 @@ class TonicTabs extends Tonic {
     }
   }
 
+  willConnect () {
+    this.panels = this.panels || {}
+  }
+
   setVisibility (id, forAttr) {
     const tabs = this.querySelectorAll('tonic-tab')
 
@@ -49,6 +54,12 @@ class TonicTabs extends Tonic {
       }
 
       if (!panel) {
+        if (this._setVisibilitySynchronously) {
+          return setImmediate(() => {
+            this.setVisibility(id, forAttr)
+          })
+        }
+
         throw new Error(`No panel found that matches the id (${control})`)
       }
 
@@ -137,11 +148,9 @@ class TonicTabs extends Tonic {
       throw new Error('missing selected property.')
     }
 
+    this._setVisibilitySynchronously = true
     this.setVisibility(id)
-  }
-
-  disconnected () {
-    delete this.panels
+    this._setVisibilitySynchronously = false
   }
 
   render () {
@@ -189,7 +198,7 @@ class TonicTabPanel extends Tonic {
   }
 
   render () {
-    console.trace('TabPanel.render()', this.id, this.visible)
+    // console.trace('TabPanel.render()', this.id, this.visible)
     if (this.visible) {
       return this.html`${this.childNodes}`
     }

--- a/tabs/test.js
+++ b/tabs/test.js
@@ -150,11 +150,11 @@ class ComponentContainer extends Tonic {
 
 Tonic.add(ComponentContainer)
 
-class TabTextBox extends Tonic {
+class TestTabTextBox extends Tonic {
   constructor (o) {
     super(o)
 
-    TabTextBox.allocationCounter++
+    TestTabTextBox.allocationCounter++
     this.renderCounter = 0
     this.willConnectCounter = 0
     this.connectedCounter = 0
@@ -188,9 +188,9 @@ class TabTextBox extends Tonic {
     return this.html`<span>${this.props.text}</span>`
   }
 }
-Tonic.add(TabTextBox)
+Tonic.add(TestTabTextBox)
 
-TabTextBox.allocationCounter = 0
+TestTabTextBox.allocationCounter = 0
 
 tape('{{tabs-3}} has correct default state', t => {
   const container = qs('component-container')
@@ -209,13 +209,13 @@ tape('tabs only render what is visible', async t => {
       </tonic-tabs>
       <main>
         <tonic-tab-panel id="tc4-panel1">
-          <tab-text-box text="Text one"></text-box>
+          <test-tab-text-box text="Text one"></text-box>
         </tonic-tab-panel>
         <tonic-tab-panel id="tc4-panel2">
-          <tab-text-box text="Text two"></text-box>
+          <test-tab-text-box text="Text two"></text-box>
         </tonic-tab-panel>
         <tonic-tab-panel id="tc4-panel3">
-          <tab-text-box text="Text three"></text-box>
+          <test-tab-text-box text="Text three"></text-box>
         </tonic-tab-panel>
       </main>
     </div>
@@ -234,11 +234,11 @@ tape('tabs only render what is visible', async t => {
     t.equal(panels.length, 1, 'expect 1 panel')
     t.equal(panels[0].id, 'tc4-panel1', 'correct panel shown')
 
-    const textboxs = $('tab-text-box')
+    const textboxs = $('test-tab-text-box')
 
     t.equal(textboxs.length, 1, 'expect 1 textbox')
     t.equal(textboxs[0].textContent, 'Text one')
-    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(TestTabTextBox.allocationCounter, 3, 'expect 3 allocations')
     t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
     t.equal(textboxs[0].connectedCounter, 1, 'expect 1 connected')
     t.equal(textboxs[0].disconnectedCounter, 0, 'expect 1 disconnected')
@@ -254,11 +254,11 @@ tape('tabs only render what is visible', async t => {
     t.equal(panels.length, 1, 'expect 1 panel')
     t.equal(panels[0].id, 'tc4-panel2', 'correct panel shown')
 
-    const textboxs = $('tab-text-box')
+    const textboxs = $('test-tab-text-box')
 
     t.equal(textboxs.length, 1, 'expect 1 textbox')
     t.equal(textboxs[0].textContent, 'Text two')
-    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(TestTabTextBox.allocationCounter, 3, 'expect 3 allocations')
     t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
     t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
     t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
@@ -274,11 +274,11 @@ tape('tabs only render what is visible', async t => {
     t.equal(panels.length, 1, 'expect 1 panel')
     t.equal(panels[0].id, 'tc4-panel3', 'correct panel shown')
 
-    const textboxs = $('tab-text-box')
+    const textboxs = $('test-tab-text-box')
 
     t.equal(textboxs.length, 1, 'expect 1 textbox')
     t.equal(textboxs[0].textContent, 'Text three')
-    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(TestTabTextBox.allocationCounter, 3, 'expect 3 allocations')
     t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
     t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
     t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
@@ -294,11 +294,11 @@ tape('tabs only render what is visible', async t => {
     t.equal(panels.length, 1, 'expect 1 panel')
     t.equal(panels[0].id, 'tc4-panel1', 'correct panel shown')
 
-    const textboxs = $('tab-text-box')
+    const textboxs = $('test-tab-text-box')
 
     t.equal(textboxs.length, 1, 'expect 1 textbox')
     t.equal(textboxs[0].textContent, 'Text one')
-    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(TestTabTextBox.allocationCounter, 3, 'expect 3 allocations')
     t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
     t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
     t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
@@ -313,11 +313,11 @@ tape('tabs only render what is visible', async t => {
     t.equal(panels.length, 1, 'expect 1 panel')
     t.equal(panels[0].id, 'tc4-panel2', 'correct panel shown')
 
-    const textboxs = $('tab-text-box')
+    const textboxs = $('test-tab-text-box')
 
     t.equal(textboxs.length, 1, 'expect 1 textbox')
     t.equal(textboxs[0].textContent, 'Text two')
-    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(TestTabTextBox.allocationCounter, 3, 'expect 3 allocations')
     t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
     t.equal(textboxs[0].connectedCounter, 3, 'expect 2 connected')
     t.equal(textboxs[0].disconnectedCounter, 2, 'expected 1 disconnected')

--- a/tabs/test.js
+++ b/tabs/test.js
@@ -150,9 +150,184 @@ class ComponentContainer extends Tonic {
 
 Tonic.add(ComponentContainer)
 
+class TabTextBox extends Tonic {
+  constructor (o) {
+    super(o)
+
+    TabTextBox.allocationCounter++
+    this.renderCounter = 0
+    this.willConnectCounter = 0
+    this.connectedCounter = 0
+    this.disconnectedCounter = 0
+  }
+
+  willConnect () {
+    this.willConnectCounter++
+  }
+
+  connected () {
+    // if (this.props.text === 'Text two') {
+    //   console.trace('connected()')
+    // }
+    this.connectedCounter++
+  }
+
+  disconnected () {
+    // if (this.props.text === 'Text two') {
+    //   console.trace('disconnected()')
+    // }
+    this.disconnectedCounter++
+    this.preventRenderOnReconnect = true
+  }
+
+  render () {
+    // if (this.props.text === 'Text two') {
+    //   console.trace('render()')
+    // }
+    this.renderCounter++
+    return this.html`<span>${this.props.text}</span>`
+  }
+}
+Tonic.add(TabTextBox)
+
+TabTextBox.allocationCounter = 0
+
 tape('{{tabs-3}} has correct default state', t => {
   const container = qs('component-container')
 
   t.ok(container, 'rendered')
   t.end()
 })
+
+tape('tabs only render what is visible', async t => {
+  document.body.appendChild(html`
+    <div id="tabs-4" class="test-container">
+      <tonic-tabs id="tc-tabs-4" selected="tc4-tab1">
+        <tonic-tab id="tc4-tab1" for="tc4-panel1">one</tonic-tab>
+        <tonic-tab id="tc4-tab2" for="tc4-panel2">two</tonic-tab>
+        <tonic-tab id="tc4-tab3" for="tc4-panel3">three</tonic-tab>
+      </tonic-tabs>
+      <main>
+        <tonic-tab-panel id="tc4-panel1">
+          <tab-text-box text="Text one"></text-box>
+        </tonic-tab-panel>
+        <tonic-tab-panel id="tc4-panel2">
+          <tab-text-box text="Text two"></text-box>
+        </tonic-tab-panel>
+        <tonic-tab-panel id="tc4-panel3">
+          <tab-text-box text="Text three"></text-box>
+        </tonic-tab-panel>
+      </main>
+    </div>
+  `)
+
+  const container = document.getElementById('tabs-4')
+  const $ = (query) => {
+    return [...container.querySelectorAll(query)]
+  }
+
+  {
+    const tabs = $('tonic-tab')
+    const panels = $('tonic-tab-panel')
+
+    t.equal(tabs.length, 3, 'expected 3 tabs')
+    t.equal(panels.length, 1, 'expect 1 panel')
+    t.equal(panels[0].id, 'tc4-panel1', 'correct panel shown')
+
+    const textboxs = $('tab-text-box')
+
+    t.equal(textboxs.length, 1, 'expect 1 textbox')
+    t.equal(textboxs[0].textContent, 'Text one')
+    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
+    t.equal(textboxs[0].connectedCounter, 1, 'expect 1 connected')
+    t.equal(textboxs[0].disconnectedCounter, 0, 'expect 1 disconnected')
+  }
+
+  const anchorTwo = $('#tc4-tab2 a')[0]
+  anchorTwo.click()
+
+  await sleep(3)
+
+  {
+    const panels = $('tonic-tab-panel')
+    t.equal(panels.length, 1, 'expect 1 panel')
+    t.equal(panels[0].id, 'tc4-panel2', 'correct panel shown')
+
+    const textboxs = $('tab-text-box')
+
+    t.equal(textboxs.length, 1, 'expect 1 textbox')
+    t.equal(textboxs[0].textContent, 'Text two')
+    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
+    t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
+    t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
+  }
+
+  const anchorThree = $('#tc4-tab3 a')[0]
+  anchorThree.click()
+
+  await sleep(3)
+
+  {
+    const panels = $('tonic-tab-panel')
+    t.equal(panels.length, 1, 'expect 1 panel')
+    t.equal(panels[0].id, 'tc4-panel3', 'correct panel shown')
+
+    const textboxs = $('tab-text-box')
+
+    t.equal(textboxs.length, 1, 'expect 1 textbox')
+    t.equal(textboxs[0].textContent, 'Text three')
+    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
+    t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
+    t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
+  }
+
+  const anchorOne = $('#tc4-tab1 a')[0]
+  anchorOne.click()
+
+  await sleep(3)
+
+  {
+    const panels = $('tonic-tab-panel')
+    t.equal(panels.length, 1, 'expect 1 panel')
+    t.equal(panels[0].id, 'tc4-panel1', 'correct panel shown')
+
+    const textboxs = $('tab-text-box')
+
+    t.equal(textboxs.length, 1, 'expect 1 textbox')
+    t.equal(textboxs[0].textContent, 'Text one')
+    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
+    t.equal(textboxs[0].connectedCounter, 2, 'expect 2 connected')
+    t.equal(textboxs[0].disconnectedCounter, 1, 'expected 1 disconnected')
+  }
+
+  anchorTwo.click()
+
+  await sleep(3)
+
+  {
+    const panels = $('tonic-tab-panel')
+    t.equal(panels.length, 1, 'expect 1 panel')
+    t.equal(panels[0].id, 'tc4-panel2', 'correct panel shown')
+
+    const textboxs = $('tab-text-box')
+
+    t.equal(textboxs.length, 1, 'expect 1 textbox')
+    t.equal(textboxs[0].textContent, 'Text two')
+    t.equal(TabTextBox.allocationCounter, 3, 'expect 3 allocations')
+    t.equal(textboxs[0].renderCounter, 1, 'expect 1 render')
+    t.equal(textboxs[0].connectedCounter, 3, 'expect 2 connected')
+    t.equal(textboxs[0].disconnectedCounter, 2, 'expected 1 disconnected')
+  }
+
+  t.end()
+})
+
+function sleep (n) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, n)
+  })
+}


### PR DESCRIPTION
The implementation of the tabs component eagerly
renders all the visual content, including the content
that's currently hidden.

These changes make it such that we do not actually
insert non-visible DOM elements into the document and
we only render them once the user changes the tab
and shows the content.

Also, when we change tabs back & forth we ensure
that we do not do extra unnecessary render calls on
the content.