### PR TITLE
src/input: Handle empty string use case

### DIFF
--- a/input/index.js
+++ b/input/index.js
@@ -21,7 +21,8 @@ class TonicInput extends Tonic {
   }
 
   get value () {
-    return this.state.value || this.props.value
+    return this.state.value !== undefined
+      ? this.state.value : this.props.value
   }
 
   set value (value) {


### PR DESCRIPTION
If the user deletes the text such that the input has
the empty string then we must return the empty string
and not whater is in `this.props.value` which is the stale
value.