### PR TITLE
Upgrade to tonic@13

### DIFF
--- a/dialog/README.md
+++ b/dialog/README.md
@@ -45,7 +45,7 @@ class TonicDialog extends Dialog {
   }
 
   render () {
-    return `
+    return this.html`
       <header>Dialog</header>
       <main>
         ${this.state.message}

--- a/dialog/index.js
+++ b/dialog/index.js
@@ -208,7 +208,7 @@ class Dialog extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))

--- a/dialog/readme.js
+++ b/dialog/readme.js
@@ -10,7 +10,7 @@ class ExampleDialog extends Dialog {
   }
 
   body () {
-    return `
+    return this.html`
       <header>Dialog</header>
       <main>
         ${this.state.message || 'Ready'}
@@ -24,7 +24,7 @@ class ExampleDialog extends Dialog {
   loading () {
     this.state.loaded = true
 
-    return `
+    return this.html`
       <h3>Loading...</h3>
     `
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1561,7 +1561,7 @@ class TonicInput extends Tonic {
     return this.html`
       <label
         for="tonic--input_${this.props.id}"
-      >${Tonic.raw(this.props.label)}</label>
+      >${this.props.label}</label>
     `
   }
 
@@ -1800,7 +1800,7 @@ class TonicLoader extends Tonic {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="outer">
         <div class="inner">
           <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1437,7 +1437,7 @@ class ExampleDialog extends Dialog {
   }
 
   body () {
-    return `
+    return this.html`
       <header>Dialog</header>
       <main>
         ${this.state.message || 'Ready'}
@@ -1451,7 +1451,7 @@ class ExampleDialog extends Dialog {
   loading () {
     this.state.loaded = true
 
-    return `
+    return this.html`
       <h3>Loading...</h3>
     `
   }
@@ -1999,7 +1999,7 @@ class TonicInput extends Tonic {
     return this.html`
       <label
         for="tonic--input_${this.props.id}"
-      >${Tonic.raw(this.props.label)}</label>
+      >${this.props.label}</label>
     `
   }
 
@@ -2251,7 +2251,7 @@ class TonicLoader extends Tonic {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="outer">
         <div class="inner">
           <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -2279,9 +2279,9 @@ class TonicLoader extends Tonic {
 module.exports = { TonicLoader }
 
 },{"@optoolco/tonic":23}],23:[function(require,module,exports){
-class TonicRaw {
+class TonicUnsafeString {
   constructor (rawText, templateStrings) {
-    this.isTonicRaw = true
+    this.isTonicUnsafeString = true
     this.rawText = rawText
     this.templateStrings = templateStrings
   }
@@ -2417,14 +2417,14 @@ class Tonic extends window.HTMLElement {
     return s.replace(Tonic.ESC, c => Tonic.MAP[c])
   }
 
-  static raw (s, templateStrings) {
-    return new TonicRaw(s, templateStrings)
+  static unsafeRawString (s, templateStrings) {
+    return new TonicUnsafeString(s, templateStrings)
   }
 
   html (strings, ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)
-      if (o && o.isTonicRaw) return o.rawText
+      if (o && o.isTonicUnsafeString) return o.rawText
       switch (Object.prototype.toString.call(o)) {
         case '[object HTMLCollection]':
         case '[object NodeList]': return this._placehold([...o])
@@ -2464,7 +2464,7 @@ class Tonic extends window.HTMLElement {
         else return ''
       }).filter(Boolean).join(' ')
     })
-    return Tonic.raw(htmlStr, strings)
+    return Tonic.unsafeRawString(htmlStr, strings)
   }
 
   scheduleReRender (oldProps) {
@@ -2532,8 +2532,10 @@ class Tonic extends window.HTMLElement {
   }
 
   _apply (target, content) {
-    if (content && content.isTonicRaw) {
+    if (content && content.isTonicUnsafeString) {
       content = content.rawText
+    } else if (typeof content === 'string') {
+      content = Tonic.escape(content)
     }
 
     if (typeof content === 'string') {
@@ -2671,35 +2673,29 @@ if (typeof module === 'object') module.exports = Tonic
 
 },{"./package":24}],24:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "@optoolco/tonic@12.1.0",
-      "/home/raynos/optoolco/components"
-    ]
-  ],
-  "_development": true,
-  "_from": "@optoolco/tonic@12.1.0",
-  "_id": "@optoolco/tonic@12.1.0",
+  "_from": "@optoolco/tonic@13.0.0",
+  "_id": "@optoolco/tonic@13.0.0",
   "_inBundle": false,
-  "_integrity": "sha512-nY5tEW0rY7NKGET/ISLgs5v3Bp9RBRFGtSK91Rx63k6bDLAE2aXObWOo62C0s8Zt+ZntzwKCX2KIpNoO245JjQ==",
+  "_integrity": "sha512-XK+aIY3J9C6dqHiBfS/IqnzZOrGrmugGHTv9xMxsVejbdO2JivBKuTTcOIXie4XWB2AA3AVO6FJc9yP35N20fA==",
   "_location": "/@optoolco/tonic",
   "_phantomChildren": {},
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "@optoolco/tonic@12.1.0",
+    "raw": "@optoolco/tonic@13.0.0",
     "name": "@optoolco/tonic",
     "escapedName": "@optoolco%2ftonic",
     "scope": "@optoolco",
-    "rawSpec": "12.1.0",
+    "rawSpec": "13.0.0",
     "saveSpec": null,
-    "fetchSpec": "12.1.0"
+    "fetchSpec": "13.0.0"
   },
   "_requiredBy": [
     "#DEV:/"
   ],
-  "_resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-12.1.0.tgz",
-  "_spec": "12.1.0",
+  "_resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-13.0.0.tgz",
+  "_shasum": "132f2cc8666d7d3331537e16904495b2d6d58755",
+  "_spec": "@optoolco/tonic@13.0.0",
   "_where": "/home/raynos/optoolco/components",
   "author": {
     "name": "optoolco"
@@ -2707,7 +2703,9 @@ module.exports={
   "bugs": {
     "url": "https://github.com/optoolco/tonic/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {},
+  "deprecated": false,
   "description": "A composable component inspired by React.",
   "devDependencies": {
     "benchmark": "^2.1.4",
@@ -2733,7 +2731,7 @@ module.exports={
     "minify": "terser index.js -c unused,dead_code,hoist_vars,loops=false,hoist_props=true,hoist_funs,toplevel,keep_classnames,keep_fargs=false -o dist/tonic.min.js",
     "test": "npm run minify && browserify test/index.js | tape-puppet"
   },
-  "version": "12.1.0"
+  "version": "13.0.0"
 }
 
 },{}],25:[function(require,module,exports){

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1391,7 +1391,7 @@ class Dialog extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))
@@ -23772,7 +23772,7 @@ class Panel extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -913,7 +913,7 @@ your own dialog class which can be registered and then used as a tag.</p>
   }
 
   render () {
-    <span class="hljs-keyword">return</span> <span class="hljs-string">`
+    <span class="hljs-keyword">return</span> <span class="hljs-built_in">this</span>.html<span class="hljs-string">`
       &lt;header&gt;Dialog&lt;/header&gt;
       &lt;main&gt;
         <span class="hljs-subst">${<span class="hljs-built_in">this</span>.state.message}</span>

--- a/docs/test.js
+++ b/docs/test.js
@@ -8624,7 +8624,7 @@ class TonicInput extends Tonic {
     return this.html`
       <label
         for="tonic--input_${this.props.id}"
-      >${Tonic.raw(this.props.label)}</label>
+      >${this.props.label}</label>
     `
   }
 
@@ -9269,7 +9269,7 @@ class TonicLoader extends Tonic {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="outer">
         <div class="inner">
           <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -9297,9 +9297,9 @@ class TonicLoader extends Tonic {
 module.exports = { TonicLoader }
 
 },{"@optoolco/tonic":50}],50:[function(require,module,exports){
-class TonicRaw {
+class TonicUnsafeString {
   constructor (rawText, templateStrings) {
-    this.isTonicRaw = true
+    this.isTonicUnsafeString = true
     this.rawText = rawText
     this.templateStrings = templateStrings
   }
@@ -9435,14 +9435,14 @@ class Tonic extends window.HTMLElement {
     return s.replace(Tonic.ESC, c => Tonic.MAP[c])
   }
 
-  static raw (s, templateStrings) {
-    return new TonicRaw(s, templateStrings)
+  static unsafeRawString (s, templateStrings) {
+    return new TonicUnsafeString(s, templateStrings)
   }
 
   html (strings, ...values) {
     const refs = o => {
       if (o && o.__children__) return this._placehold(o)
-      if (o && o.isTonicRaw) return o.rawText
+      if (o && o.isTonicUnsafeString) return o.rawText
       switch (Object.prototype.toString.call(o)) {
         case '[object HTMLCollection]':
         case '[object NodeList]': return this._placehold([...o])
@@ -9482,7 +9482,7 @@ class Tonic extends window.HTMLElement {
         else return ''
       }).filter(Boolean).join(' ')
     })
-    return Tonic.raw(htmlStr, strings)
+    return Tonic.unsafeRawString(htmlStr, strings)
   }
 
   scheduleReRender (oldProps) {
@@ -9550,8 +9550,10 @@ class Tonic extends window.HTMLElement {
   }
 
   _apply (target, content) {
-    if (content && content.isTonicRaw) {
+    if (content && content.isTonicUnsafeString) {
       content = content.rawText
+    } else if (typeof content === 'string') {
+      content = Tonic.escape(content)
     }
 
     if (typeof content === 'string') {
@@ -9689,35 +9691,29 @@ if (typeof module === 'object') module.exports = Tonic
 
 },{"./package":51}],51:[function(require,module,exports){
 module.exports={
-  "_args": [
-    [
-      "@optoolco/tonic@12.1.0",
-      "/home/raynos/optoolco/components"
-    ]
-  ],
-  "_development": true,
-  "_from": "@optoolco/tonic@12.1.0",
-  "_id": "@optoolco/tonic@12.1.0",
+  "_from": "@optoolco/tonic@13.0.0",
+  "_id": "@optoolco/tonic@13.0.0",
   "_inBundle": false,
-  "_integrity": "sha512-nY5tEW0rY7NKGET/ISLgs5v3Bp9RBRFGtSK91Rx63k6bDLAE2aXObWOo62C0s8Zt+ZntzwKCX2KIpNoO245JjQ==",
+  "_integrity": "sha512-XK+aIY3J9C6dqHiBfS/IqnzZOrGrmugGHTv9xMxsVejbdO2JivBKuTTcOIXie4XWB2AA3AVO6FJc9yP35N20fA==",
   "_location": "/@optoolco/tonic",
   "_phantomChildren": {},
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "@optoolco/tonic@12.1.0",
+    "raw": "@optoolco/tonic@13.0.0",
     "name": "@optoolco/tonic",
     "escapedName": "@optoolco%2ftonic",
     "scope": "@optoolco",
-    "rawSpec": "12.1.0",
+    "rawSpec": "13.0.0",
     "saveSpec": null,
-    "fetchSpec": "12.1.0"
+    "fetchSpec": "13.0.0"
   },
   "_requiredBy": [
     "#DEV:/"
   ],
-  "_resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-12.1.0.tgz",
-  "_spec": "12.1.0",
+  "_resolved": "https://registry.npmjs.org/@optoolco/tonic/-/tonic-13.0.0.tgz",
+  "_shasum": "132f2cc8666d7d3331537e16904495b2d6d58755",
+  "_spec": "@optoolco/tonic@13.0.0",
   "_where": "/home/raynos/optoolco/components",
   "author": {
     "name": "optoolco"
@@ -9725,7 +9721,9 @@ module.exports={
   "bugs": {
     "url": "https://github.com/optoolco/tonic/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {},
+  "deprecated": false,
   "description": "A composable component inspired by React.",
   "devDependencies": {
     "benchmark": "^2.1.4",
@@ -9751,7 +9749,7 @@ module.exports={
     "minify": "terser index.js -c unused,dead_code,hoist_vars,loops=false,hoist_props=true,hoist_funs,toplevel,keep_classnames,keep_fargs=false -o dist/tonic.min.js",
     "test": "npm run minify && browserify test/index.js | tape-puppet"
   },
-  "version": "12.1.0"
+  "version": "13.0.0"
 }
 
 },{}],52:[function(require,module,exports){
@@ -33793,7 +33791,7 @@ class ExamplePanel extends Panel {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="tonic--header">Panel Example</div>
       <div class="tonic--main">
         <h3>${this.props.title || 'Hello'}

--- a/docs/test.js
+++ b/docs/test.js
@@ -7913,7 +7913,7 @@ class Dialog extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))
@@ -33738,7 +33738,7 @@ class Panel extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))

--- a/input/index.js
+++ b/input/index.js
@@ -178,7 +178,7 @@ class TonicInput extends Tonic {
     return this.html`
       <label
         for="tonic--input_${this.props.id}"
-      >${Tonic.raw(this.props.label)}</label>
+      >${this.props.label}</label>
     `
   }
 

--- a/loader/index.js
+++ b/loader/index.js
@@ -26,7 +26,7 @@ class TonicLoader extends Tonic {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="outer">
         <div class="inner">
           <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "testcafe": "1.6.1"
   },
   "devDependencies": {
-    "@optoolco/tonic": "12.1.0",
+    "@optoolco/tonic": "13.0.0",
     "@pre-bundled/send": "0.16.2-patch-1",
     "@pre-bundled/tape": "4.11.0",
     "chart.js": "^2.9.2",

--- a/panel/index.js
+++ b/panel/index.js
@@ -205,7 +205,7 @@ class Panel extends Tonic {
 
       if (typeof content === 'string') {
         contentContainer.innerHTML = content
-      } else if (content.isTonicRaw) {
+      } else if (content.isTonicUnsafeString) {
         contentContainer.innerHTML = content.rawText
       } else {
         [...content.childNodes].forEach(el => contentContainer.appendChild(el))

--- a/panel/test.js
+++ b/panel/test.js
@@ -15,7 +15,7 @@ class ExamplePanel extends Panel {
   }
 
   render () {
-    return `
+    return this.html`
       <div class="tonic--header">Panel Example</div>
       <div class="tonic--main">
         <h3>${this.props.title || 'Hello'}


### PR DESCRIPTION
This bumps tonic and updates components.

The only breaking change I found was removing the
Tonic.raw() for labels in `<tonic-input>`. If you
want a non-text label you have to add your own `<label>`
adjacent to `<tonic-input>` instead of putting raw HTML
in the `label="..."` attribute of `tonic-input`.

r: @heapwolf