### PR TITLE
tonic-input was not working in wizard.

### DIFF
--- a/button/index.js
+++ b/button/index.js
@@ -257,4 +257,3 @@ class TonicButton extends Tonic {
 }
 
 module.exports = { TonicButton }
-

--- a/input/index.js
+++ b/input/index.js
@@ -9,7 +9,6 @@ class TonicInput extends Tonic {
   defaults () {
     return {
       type: 'text',
-      value: '',
       placeholder: '',
       color: 'var(--tonic-primary)',
       spellcheck: false,
@@ -26,8 +25,13 @@ class TonicInput extends Tonic {
   }
 
   get value () {
-    return this.state.value !== undefined
-      ? this.state.value : this.props.value
+    if (this._modified) {
+      return typeof this.state.value === 'string'
+        ? this.state.value : this.props.value
+    } else {
+      return typeof this.props.value === 'string'
+        ? this.props.value : this.state.value
+    }
   }
 
   set value (value) {
@@ -327,11 +331,7 @@ class TonicInput extends Tonic {
     if (tabindex) this.removeAttribute('tabindex')
     if (theme) this.classList.add(`tonic--theme--${theme}`)
 
-    const value = this._modified
-      ? typeof this.state.value === 'string'
-        ? this.state.value
-        : this.props.value
-      : this.props.value
+    const value = this.value
 
     const errorMessage = this.props.errorMessage ||
       this.props.errormessage || 'Invalid'

--- a/input/test.js
+++ b/input/test.js
@@ -399,6 +399,9 @@ tape('input wrapper component interactions', t => {
     t.equal(display.textContent, 'someText')
     t.equal(comp.state.inputEvents, 1)
 
+    const input2 = comp.querySelector('input')
+    t.equal(input2.value, 'someText')
+
     t.end()
   }, 20)
 })


### PR DESCRIPTION
When the component reRendered it defaulted to
empty string even though there was text in the
input previously.

This is because the parent's parent reRendered
and the `_modified` is false as its a new DOM
element.