### PR TITLE
Update documentation for events.

### DIFF
--- a/docs/src/markdown/events.md
+++ b/docs/src/markdown/events.md
@@ -80,35 +80,25 @@ Tonic.match(el, 'selector')
 ```
 
 Here, when a particular element inside a child component is clicked, we
-intercept the click event and pass along some data to the parent component.
+attach a click event handler in the parent component by relying on bubbling.
 
 ### Example
 ```js
 class ChildElement extends Tonic {
-  click (e) {
-    const el = Tonic.match(e.target, '[data-event]')
-    if (!el) return
-
-    if (el.dataset.event === 'click-me') {
-      this.dispatch('specialclick', { bar: true })
-    }
-  }
   render () {
     return this.html`
-      <span data-event="click-me">Click Me</span>
+      <span data-event="click-me" data-bar="true">Click Me</span>
     `
   }
 }
 
 class ParentElement extends Tonic {
-  constructor () {
-    super()
+  click (ev) {
+    const el = Tonic.match(ev.target, '[data-event]')
 
-    this.addEventListener('specialclick', this)
-  }
-
-  specialclick (ev) {
-    console.log(ev.detail.bar)
+    if (el.dataset.event === 'click-me') {
+      console.log(el.dataset.bar)
+    }
   }
 
   render () {
@@ -119,10 +109,6 @@ class ParentElement extends Tonic {
   }
 }
 ```
-
-Tonic providers a helper `this.dispatch` method that you can use
-to dispatch custom events. The [`EventTarget.addEventListener`][10] method
-is built into the dom
 
 The event object has a [`Event.stopPropagation()`][8] method that is useful for
 preventing an event from bubbling up to parent components. You may also be

--- a/docs/src/markdown/events.md
+++ b/docs/src/markdown/events.md
@@ -79,8 +79,9 @@ selector, and if not, tries to find the closest match.
 Tonic.match(el, 'selector')
 ```
 
-Here, when a particular element inside a child component is clicked, we
-attach a click event handler in the parent component by relying on bubbling.
+You can attach an event handler in any component, for example here
+we attach an event handler in a `ParentElement` component that handles
+clicks from DOM elements in `ChildElement`.
 
 ### Example
 ```js

--- a/docs/src/markdown/events.md
+++ b/docs/src/markdown/events.md
@@ -94,8 +94,8 @@ class ChildElement extends Tonic {
 }
 
 class ParentElement extends Tonic {
-  click (ev) {
-    const el = Tonic.match(ev.target, '[data-event]')
+  click (e) {
+    const el = Tonic.match(e.target, '[data-event]')
 
     if (el.dataset.event === 'click-me') {
       console.log(el.dataset.bar)

--- a/docs/src/markdown/events.md
+++ b/docs/src/markdown/events.md
@@ -86,21 +86,31 @@ intercept the click event and pass along some data to the parent component.
 ```js
 class ChildElement extends Tonic {
   click (e) {
-    e.detail.bar = true
+    const el = Tonic.match(e.target, '[data-event]')
+    if (!el) return
+
+    if (el.dataset.event === 'click-me') {
+      this.dispatch('specialclick', { bar: true })
+    }
   }
   render () {
     return this.html`
-      Click Me
+      <span data-event="click-me">Click Me</span>
     `
   }
 }
 
 class ParentElement extends Tonic {
-  click (e) {
-    if (e.target.matches('child-element')) {
-      console.log(e.detail.bar)
-    }
+  constructor () {
+    super()
+
+    this.addEventListener('specialclick', this)
   }
+
+  specialclick (ev) {
+    console.log(ev.detail.bar)
+  }
+
   render () {
     return this.html`
       <child-element>
@@ -109,6 +119,10 @@ class ParentElement extends Tonic {
   }
 }
 ```
+
+Tonic providers a helper `this.dispatch` method that you can use
+to dispatch custom events. The [`EventTarget.addEventListener`][10] method
+is built into the dom
 
 The event object has a [`Event.stopPropagation()`][8] method that is useful for
 preventing an event from bubbling up to parent components. You may also be
@@ -119,3 +133,4 @@ interested in the [`Event.preventDefault()`][9] method.
 [7]:https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
 [8]:https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation
 [9]:https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault
+[10]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "testcafe": "1.6.1"
   },
   "devDependencies": {
-    "@optoolco/tonic": "13.1.2",
+    "@optoolco/tonic": "13.1.3",
     "@pre-bundled/send": "0.16.2-patch-1",
     "@pre-bundled/tape": "4.11.0",
     "chart.js": "^2.9.2",

--- a/test/fixtures/test-form.js
+++ b/test/fixtures/test-form.js
@@ -49,18 +49,13 @@ class TestForm extends Tonic {
 Tonic.add(TestForm)
 
 class CustomEventTest extends Tonic {
-  click (e) {
-    const el = Tonic.match(e.target, '[data-event]')
-    if (!el) return
-
-    if (el.dataset.event === 'click-me') {
-      this.dispatch('specialclick', { bar: 'hmm' })
-    }
-  }
-
   render () {
     return this.html`
-      <span class="test-click-me" data-event="click-me">
+      <span
+        class="test-click-me"
+        data-event="click-me"
+        data-bar="hmm"
+      >
         Click Me
       </span>
     `
@@ -72,16 +67,18 @@ class CustomEventParent extends Tonic {
   constructor () {
     super()
 
-    this.addEventListener('specialclick', this)
-
     this.state = {
       text: 'empty'
     }
   }
 
-  specialclick (ev) {
-    this.state.text = ev.detail.bar
-    this.reRender()
+  click (ev) {
+    const el = Tonic.match(ev.target, '[data-event]')
+
+    if (el.dataset.event === 'click-me') {
+      this.state.text = el.dataset.bar
+      this.reRender()
+    }
   }
 
   render () {

--- a/test/fixtures/test-form.js
+++ b/test/fixtures/test-form.js
@@ -47,3 +47,49 @@ class TestForm extends Tonic {
 }
 
 Tonic.add(TestForm)
+
+class CustomEventTest extends Tonic {
+  click (e) {
+    const el = Tonic.match(e.target, '[data-event]')
+    if (!el) return
+
+    if (el.dataset.event === 'click-me') {
+      this.dispatch('specialclick', { bar: 'hmm' })
+    }
+  }
+
+  render () {
+    return this.html`
+      <span class="test-click-me" data-event="click-me">
+        Click Me
+      </span>
+    `
+  }
+}
+Tonic.add(CustomEventTest)
+
+class CustomEventParent extends Tonic {
+  constructor () {
+    super()
+
+    this.addEventListener('specialclick', this)
+
+    this.state = {
+      text: 'empty'
+    }
+  }
+
+  specialclick (ev) {
+    this.state.text = ev.detail.bar
+    this.reRender()
+  }
+
+  render () {
+    return this.html`
+      <span>Text is: ${this.state.text}</span>
+      <custom-event-test>
+      </custom-event-test>
+    `
+  }
+}
+Tonic.add(CustomEventParent)

--- a/test/fixtures/testcafe.js
+++ b/test/fixtures/testcafe.js
@@ -63,5 +63,6 @@ document.body.appendChild(html`
     }
     </style>
     <test-form id="test-form"></test-form>
+    <custom-event-parent id="custom-event-parent"></custom-event-parent>
   </div>
 `)

--- a/test/testcafe/test-form.ts
+++ b/test/testcafe/test-form.ts
@@ -24,3 +24,22 @@ test('can click button', async (t) => {
   })
   await t.expect(c).eql(1)
 });
+
+test('can dispatch custome vent', async (t) => {
+  const parent = Selector('custom-event-parent')
+
+  {
+    const span = parent.find('span').withText(/Text is: /i)
+    await t.expect(span.visible).eql(true)
+    await t.expect(span.textContent).eql('Text is: empty')
+  }
+
+  const clickMe = parent.find('.test-click-me')
+  await t.click(clickMe)
+
+  {
+    const span = parent.find('span').withText(/Text is: /i)
+    await t.expect(span.visible).eql(true)
+    await t.expect(span.textContent).eql('Text is: hmm')
+  }
+})


### PR DESCRIPTION
There were two issues in the example, using `detail`
for a builtin event and using `el.matches` instead of
`Tonic.match()`.